### PR TITLE
Mpc update

### DIFF
--- a/mpc-wallet/.gitlab-ci.yml
+++ b/mpc-wallet/.gitlab-ci.yml
@@ -28,9 +28,15 @@ test-mpc-wallet-wasm:
     - cd mpc-wallet-wasm
     - cargo build --release
     - cargo test --release
+    - cargo build --release --no-default-features --features k256
+    - cargo test --release --no-default-features --features k256
     - wasm-pack build --release --target bundler
     - wasm-opt --enable-mutable-globals -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
     - wasm-pack build --release --target nodejs
+    - wasm-opt --enable-mutable-globals -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
+    - wasm-pack build --release --target bundler -- --no-default-features --features k256
+    - wasm-opt --enable-mutable-globals -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
+    - wasm-pack build --release --target nodejs -- --no-default-features --features k256
     - wasm-opt --enable-mutable-globals -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
 
 test-bigints:
@@ -50,10 +56,14 @@ test-mpc-wallet-lib:
   stage: test
   script:
     - cd mpc-wallet-lib
-    - cargo build --no-default-features --features rust_gmp --release
-    - cargo test --no-default-features --features rust_gmp --release
-    - cargo build --no-default-features --features num_bigint --release
-    - cargo test --no-default-features --features num_bigint --release
+    - cargo build --release
+    - cargo test --release
+    - cargo build --no-default-features --features rust_gmp --features k256 --release
+    - cargo test --no-default-features --features rust_gmp --features k256 --release
+    - cargo build --no-default-features --features num_bigint --features k256 --release
+    - cargo test --no-default-features --features num_bigint --features k256 --release
+    - cargo build --no-default-features --features num_bigint --features secp256k1 --release
+    - cargo test --no-default-features --features num_bigint --features secp256k1 --release
 
 test-mpc-wallet-elixir:
   <<: *rust-template
@@ -61,6 +71,7 @@ test-mpc-wallet-elixir:
   script:
     - cd mpc-wallet-elixir
     - cargo build --release
+    - cargo build --release --no-default-features --features k256
 
 test-rust-paillier:
   <<: *rust-template
@@ -82,3 +93,5 @@ test-mpc-wallet-nodejs:
     - cd native
     - cargo build --release
     - cargo test --release
+    - cargo build --release --no-default-features --features k256
+    - cargo test --release --no-default-features --features k256

--- a/mpc-wallet/FUTURE_WORK
+++ b/mpc-wallet/FUTURE_WORK
@@ -3,5 +3,4 @@
 
 -) Find some maintained Paillier library for Rust and replace rust-paillier therewith.
 
--) Consider replacing secp256k1 with https://github.com/RustCrypto/elliptic-curves/tree/master/k256 (-> pure Rust) and amcl with https://github.com/RustCrypto/elliptic-curves/tree/master/p256 (-> potentially smaller WASM binary) as soon as those libraries are ready.
-
+-) Replace secp256k1 with k256 as soon as it is fast enough.

--- a/mpc-wallet/demo/client/index.js
+++ b/mpc-wallet/demo/client/index.js
@@ -180,7 +180,7 @@ async function compute_presig() {
             signature_html.innerHTML = "r:" + JSON.stringify(r) + ", s:" + JSON.stringify(s) + ", recovery_id:" + recovery_id;
             console.log("Server has completed the signature.")
             let result = JSON.parse(MPCwallet.verify(r, s, get_state("public_key"), message_hash, curve));
-            if (result[0] === true){
+            if (result === true){
                 console.log("Signature verified successfully.");
             } else {
                 console.log("Error verifying signature. " + result[1]);

--- a/mpc-wallet/demo/client/index.js
+++ b/mpc-wallet/demo/client/index.js
@@ -172,6 +172,8 @@ async function compute_presig() {
             presig: presig,
             r: r,
             curve: curve,
+            pubkey: JSON.parse(get_state("public_key")),
+            msg_hash: message_hash,
         }).then((response) =>{
             let recovery_id = response.data["recovery_id"];
             let r = response.data["r"];

--- a/mpc-wallet/demo/server/lib/mpcwallet.ex
+++ b/mpc-wallet/demo/server/lib/mpcwallet.ex
@@ -60,6 +60,8 @@ defmodule Server.MPCwallet do
       - r: random value shared between server and client
       - k: server part of the nonce used in the signature
       - curve: Secp256k1 or Secp256r1 curve
+      - public_key: public key under which the completed signature is (supposed to be) valid
+      - msg_hash: hash of the message under which the completed signature is (supposed to be) valid
 
   ## Returns
 
@@ -68,7 +70,7 @@ defmodule Server.MPCwallet do
       - recovery_id: 2 bits that help recovering the public key from a signature
 
   """
-  def complete_sig(_paillier_sk, _presig, _r, _k, _curve), do: :erlang.nif_error(:nif_not_loaded)
+  def complete_sig(_paillier_sk, _presig, _r, _k, _curve, _pubkey, _msg_hash), do: :erlang.nif_error(:nif_not_loaded)
 
 
   @doc ~S"""

--- a/mpc-wallet/mpc-wallet-elixir/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-elixir/Cargo.toml
@@ -7,8 +7,13 @@ edition = "2018"
 name = "mpc_wallet_elixir"
 crate-type = ["dylib"]
 
+[features]
+default = ["secp256k1"]
+k256 = ["mpc-wallet-lib/k256"]
+secp256k1 = ["mpc-wallet-lib/secp256k1"]
+
 [dependencies]
-mpc-wallet-lib = { version = "*", path = '../mpc-wallet-lib' }
+mpc-wallet-lib = { version = "*", path = '../mpc-wallet-lib', default-features = false, features = ["rust_gmp"] }
 rustler = "0.21"
 serde_json = "1.0"
 

--- a/mpc-wallet/mpc-wallet-elixir/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-elixir/src/lib.rs
@@ -242,16 +242,10 @@ fn verify<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
     };
 
-    let result = match common::verify(&r, &s, &pubkey, &msg_hash, curve) {
-        Ok(v) => v,
-        Err(_) => {
-            return Ok((atoms::error(), &"error: invalid pubkey or invalid curve").encode(env))
-        }
-    };
-    if result {
-        Ok((atoms::ok(), atoms::__true__()).encode(env))
+    if common::verify(&r, &s, &pubkey, &msg_hash, curve) {
+        Ok(atoms::ok().encode(env))
     } else {
-        Ok((atoms::error(), atoms::__false__()).encode(env))
+        Ok(atoms::error().encode(env))
     }
 }
 

--- a/mpc-wallet/mpc-wallet-lib/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-lib/Cargo.toml
@@ -15,17 +15,18 @@ wasm = ["chrono/wasmbind", "getrandom/js"]
 
 [dependencies]
 chrono = "0.4"
+generic-array = "0.14"
 getrandom = "0.2"
 indexmap = "1.3"
 lazy_static = "1.4"
+p256 = { version = "0.5", features = ["ecdsa"] }
 rayon = "1.3"
 secp256k1 = { version = "0.19.0" }
 serde = "1.0"
 sha2 = "0.9"
-subtle = "2.2"
+subtle = "2.3"
 num-integer = { version = "0.1", optional = true }
 num-traits = { version = "0.2", optional = true }
-amcl = { version = "0.2", default-features = false, features = ["nist256"] }
 zeroize = { version = "1.1", default-features = false }
 rust-bigint = { version = "1.1", default-features = false }
 paillier-common = { version = "0.1", default-features = false }

--- a/mpc-wallet/mpc-wallet-lib/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-lib/Cargo.toml
@@ -8,7 +8,7 @@ description = "MPC wallet library"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["rust_gmp"]
+default = ["rust_gmp", "secp256k1"]
 rust_gmp = ["rust-bigint/rust_gmp", "paillier-common/rust_gmp"]
 num_bigint = ["rust-bigint/num_bigint", "paillier-common/num_bigint", "num-integer", "num-traits"]
 wasm = ["chrono/wasmbind", "getrandom/js"]
@@ -18,10 +18,11 @@ chrono = "0.4"
 generic-array = "0.14"
 getrandom = "0.2"
 indexmap = "1.3"
+k256 = { version = "0.5", features = ["ecdsa"], optional = true }
 lazy_static = "1.4"
 p256 = { version = "0.5", features = ["ecdsa"] }
 rayon = "1.3"
-secp256k1 = { version = "0.19.0" }
+secp256k1 = { version = "0.19.0", optional = true }
 serde = "1.0"
 sha2 = "0.9"
 subtle = "2.3"

--- a/mpc-wallet/mpc-wallet-lib/benches/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/common.rs
@@ -51,8 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&pk_k1),
                 black_box(&msg_hash),
                 black_box(Curve::Secp256k1),
-            )
-            .unwrap();
+            );
         })
     });
 
@@ -69,8 +68,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&pk_r1),
                 black_box(&msg_hash),
                 black_box(Curve::Secp256r1),
-            )
-            .unwrap();
+            );
         })
     });
 }

--- a/mpc-wallet/mpc-wallet-lib/benches/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/common.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate criterion;
 
-use rust_bigint::traits::Converter;
-use rust_bigint::BigInt;
 use criterion::{black_box, Criterion};
 use mpc_wallet_lib::common::{
     dh_init_secp256k1, dh_init_secp256r1, publickey_from_secretkey, verify, Curve,
 };
+use rust_bigint::traits::Converter;
+use rust_bigint::BigInt;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("dh_init_secp256k1", |b| {

--- a/mpc-wallet/mpc-wallet-lib/benches/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/server.rs
@@ -56,6 +56,29 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
         })
     });
+
+    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), Curve::Secp256r1).unwrap();
+    let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("b666e18f83bd0f642a3a3831f7f87c81b56fe751ecaa5e8f6b31c8fdb97e757a1e0bb9ec44d66775af88289501f9ab5c27aba18561096593270033561c2dd9e00407981a721fe5fd982693f13777759c7469ec72ce181da61ea07be1a754982869929a7033e3647254d9044556d4045b412ab60fa290aa8f7e731045539cad1f").unwrap(), q: BigInt::from_hex("bb1704bebe7b50a1dc2e8b3cb868b7aebde79f603ae753e5e1a9685c2950f3502509886c26edbc4641f1544a97059299677c4dc3ec760b1472c212b5547cd32b1134bf2d3e8cfa801f9f637e8121dec460d99851398651253a5243465e02a77583b48d1463ee594c0d626f9d9ae78bd56052a31c0aab3dbbd8da96eadf0c6bff").unwrap()});
+    let presig_r1 = BigInt::from_hex("112164aec0e4e1be041e43537ce94d75969d7bfd59579355456690f0d593d5b697c4be5f2a13929c5d9b6dd64bd53186c1bd869f1321ba32427e884ee81bacdb49654d6d481eeb14198b3d61a013ffea5bbd058799e7ee828eb15b3541003e67d23c5e1af87021a86b38b75468ee7df7ff595d0e138b361599371698b90fa59a3695574fb56d08fdcc32e1a35c7708ec7e12574d3c68863106c84b8053bd2e0218fcdb31fbcc6351674f274f2aa356c7b7556abb1a55fdf0e17bdd8a0003cb8221850115933aa74b68c84ebcf426636194d6717fc96ca071f3387f2d711637a9fea995a668e1064e0d6c39898ea10c655351f53801ba939327565da4bc960a20481c9f86c2344888b36df9189b58038b3822f70a431fbe82c584a4f4657d742e6a2976f6f956f722b6cc781d8f7367134b2b883a93614af92764af715bb6fcc6d14e490c7f942f6678e4f3a2ebe361c52b95f6056f1d6e20f8260b101a494f9e6fc1fdbf9d2b563be7a6791ceeb8e035a6f07c989f63e313662ef96ec663529896639e461c20ba65a1729a95b09e85ce67704b3d4ef0098b669b1bb57ea216dc60013f2c721f0ba1ce472c3cba24d88b6707bdf0f4a34b6dd75b9b6e10b4c3a7ec60380179dba76e45d472224bc7e8c452873ffa49d7c9e0eab712403a468024a509748da45d0218384d58acf8239614f7e4332cc34a7e68552f738bf50c78c6").unwrap();
+    let r_r1 =
+        BigInt::from_hex("3c8c36274f450152eeac61fed4d81ca470fe5b4659e64bc3b343eaee9a5b37b55")
+            .unwrap();
+    let k_r1 = BigInt::from_hex("581b8e054da08a656d3cb821ae1989ac1978cda5052b89f08b13d43a414f4c4a")
+        .unwrap();
+    c.bench_function("complete_sig_r1", |b| {
+        b.iter(|| {
+            complete_sig(
+                black_box(&paillier_sk),
+                black_box(&presig_r1),
+                black_box(&r_r1),
+                black_box(&k_r1),
+                black_box(Curve::Secp256r1),
+                black_box(&pk),
+                black_box(&msg_hash),
+            )
+            .unwrap();
+        })
+    });
 }
 
 criterion_group! {

--- a/mpc-wallet/mpc-wallet-lib/benches/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/server.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 use rust_bigint::traits::Converter;
 use rust_bigint::BigInt;
 use criterion::{black_box, Criterion};
-use mpc_wallet_lib::common::{dh_init_secp256k1, dh_init_secp256r1, Curve};
+use mpc_wallet_lib::common::{dh_init_secp256k1, dh_init_secp256r1, Curve, publickey_from_secretkey};
 use mpc_wallet_lib::server::{
     complete_sig, compute_rpool_secp256k1, compute_rpool_secp256r1, generate_paillier_proof,
 };
@@ -38,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
     let k_k1 = BigInt::from_hex("b95d4e79d09b35bdfc863cdeb8bbfd85d557546e75fe2582961fbe0497525f6e")
         .unwrap();
-    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), Curve::Secp256k1).unwrap();
     let msg_hash =
         BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
             .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/benches/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/server.rs
@@ -38,6 +38,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
     let k_k1 = BigInt::from_hex("b95d4e79d09b35bdfc863cdeb8bbfd85d557546e75fe2582961fbe0497525f6e")
         .unwrap();
+    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+    let msg_hash =
+        BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+            .unwrap();
     c.bench_function("complete_sig_k1", |b| {
         b.iter(|| {
             complete_sig(
@@ -46,6 +50,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&r_k1),
                 black_box(&k_k1),
                 black_box(Curve::Secp256k1),
+                black_box(&pk),
+                black_box(&msg_hash),
             )
             .unwrap();
         })

--- a/mpc-wallet/mpc-wallet-lib/benches/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/benches/server.rs
@@ -1,14 +1,16 @@
 #[macro_use]
 extern crate criterion;
 
-use rust_bigint::traits::Converter;
-use rust_bigint::BigInt;
 use criterion::{black_box, Criterion};
-use mpc_wallet_lib::common::{dh_init_secp256k1, dh_init_secp256r1, Curve, publickey_from_secretkey};
+use mpc_wallet_lib::common::{
+    dh_init_secp256k1, dh_init_secp256r1, publickey_from_secretkey, Curve,
+};
 use mpc_wallet_lib::server::{
     complete_sig, compute_rpool_secp256k1, compute_rpool_secp256r1, generate_paillier_proof,
 };
 use paillier_common::{DecryptionKey, MinimalDecryptionKey};
+use rust_bigint::traits::Converter;
+use rust_bigint::BigInt;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
@@ -38,7 +40,12 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
     let k_k1 = BigInt::from_hex("b95d4e79d09b35bdfc863cdeb8bbfd85d557546e75fe2582961fbe0497525f6e")
         .unwrap();
-    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), Curve::Secp256k1).unwrap();
+    let pk = publickey_from_secretkey(
+        &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+            .unwrap(),
+        Curve::Secp256k1,
+    )
+    .unwrap();
     let msg_hash =
         BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
             .unwrap();
@@ -57,7 +64,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), Curve::Secp256r1).unwrap();
+    let pk = publickey_from_secretkey(
+        &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+            .unwrap(),
+        Curve::Secp256r1,
+    )
+    .unwrap();
     let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("b666e18f83bd0f642a3a3831f7f87c81b56fe751ecaa5e8f6b31c8fdb97e757a1e0bb9ec44d66775af88289501f9ab5c27aba18561096593270033561c2dd9e00407981a721fe5fd982693f13777759c7469ec72ce181da61ea07be1a754982869929a7033e3647254d9044556d4045b412ab60fa290aa8f7e731045539cad1f").unwrap(), q: BigInt::from_hex("bb1704bebe7b50a1dc2e8b3cb868b7aebde79f603ae753e5e1a9685c2950f3502509886c26edbc4641f1544a97059299677c4dc3ec760b1472c212b5547cd32b1134bf2d3e8cfa801f9f637e8121dec460d99851398651253a5243465e02a77583b48d1463ee594c0d626f9d9ae78bd56052a31c0aab3dbbd8da96eadf0c6bff").unwrap()});
     let presig_r1 = BigInt::from_hex("112164aec0e4e1be041e43537ce94d75969d7bfd59579355456690f0d593d5b697c4be5f2a13929c5d9b6dd64bd53186c1bd869f1321ba32427e884ee81bacdb49654d6d481eeb14198b3d61a013ffea5bbd058799e7ee828eb15b3541003e67d23c5e1af87021a86b38b75468ee7df7ff595d0e138b361599371698b90fa59a3695574fb56d08fdcc32e1a35c7708ec7e12574d3c68863106c84b8053bd2e0218fcdb31fbcc6351674f274f2aa356c7b7556abb1a55fdf0e17bdd8a0003cb8221850115933aa74b68c84ebcf426636194d6717fc96ca071f3387f2d711637a9fea995a668e1064e0d6c39898ea10c655351f53801ba939327565da4bc960a20481c9f86c2344888b36df9189b58038b3822f70a431fbe82c584a4f4657d742e6a2976f6f956f722b6cc781d8f7367134b2b883a93614af92764af715bb6fcc6d14e490c7f942f6678e4f3a2ebe361c52b95f6056f1d6e20f8260b101a494f9e6fc1fdbf9d2b563be7a6791ceeb8e035a6f07c989f63e313662ef96ec663529896639e461c20ba65a1729a95b09e85ce67704b3d4ef0098b669b1bb57ea216dc60013f2c721f0ba1ce472c3cba24d88b6707bdf0f4a34b6dd75b9b6e10b4c3a7ec60380179dba76e45d472224bc7e8c452873ffa49d7c9e0eab712403a468024a509748da45d0218384d58acf8239614f7e4332cc34a7e68552f738bf50c78c6").unwrap();
     let r_r1 =

--- a/mpc-wallet/mpc-wallet-lib/src/client.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/client.rs
@@ -8,8 +8,6 @@ use crate::common::{
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
-use rust_bigint::traits::{Converter, Modulo, Samplable, ZeroizeBN};
-use rust_bigint::BigInt;
 use chrono::prelude::{DateTime, Utc};
 use chrono::Duration;
 use indexmap::{IndexMap, IndexSet};
@@ -25,6 +23,8 @@ use paillier_common::{
 };
 #[cfg(not(feature = "wasm"))]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rust_bigint::traits::{Converter, Modulo, Samplable, ZeroizeBN};
+use rust_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 use zeroize::Zeroize;
@@ -288,9 +288,9 @@ pub fn fill_rpool_secp256r1(
     for i in 0..own_dh_secrets.len() {
         match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
             Ok(r) => RPOOL_SECP256R1
-                        .lock()
-                        .unwrap()
-                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+                .lock()
+                .unwrap()
+                .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
             Err(_) => None,
         };
     }
@@ -298,9 +298,9 @@ pub fn fill_rpool_secp256r1(
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
         match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
             Ok(r) => RPOOL_SECP256R1
-                        .lock()
-                        .unwrap()
-                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+                .lock()
+                .unwrap()
+                .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
             Err(_) => None,
         };
     });
@@ -325,9 +325,9 @@ pub fn fill_rpool_secp256k1(
     for i in 0..own_dh_secrets.len() {
         match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
             Ok(r) => RPOOL_SECP256K1
-                        .lock()
-                        .unwrap()
-                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+                .lock()
+                .unwrap()
+                .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
             Err(_) => None,
         };
     }
@@ -335,9 +335,9 @@ pub fn fill_rpool_secp256k1(
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
         match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
             Ok(r) => RPOOL_SECP256K1
-                        .lock()
-                        .unwrap()
-                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+                .lock()
+                .unwrap()
+                .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
             Err(_) => None,
         };
     });
@@ -426,9 +426,9 @@ mod tests {
     use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
     use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
     use crate::curves::traits::ECScalar;
+    use paillier_common::{EncryptionKey, MinimalEncryptionKey};
     use rust_bigint::traits::Converter;
     use rust_bigint::BigInt;
-    use paillier_common::{EncryptionKey, MinimalEncryptionKey};
     use std::sync::Mutex;
 
     lazy_static! {
@@ -553,7 +553,8 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("8ea92bf3aa6f4ec4939b0888cd71dc6dc113f9cafe571c0bb501c8c9004bb47c")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("34bfa8dd79ff0777e32b89f22a19623ff4fe6fe63aaeb3e2d165fc12cbb2471db")
                 .unwrap(),
@@ -598,7 +599,8 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("EAB592977DF1A8E7D77DB58F4DAE73C860920D28B763A0737217D3793563D53E")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2366a21b029c2e4d627ac5f7e94769ed1b28727f2403b54c8deb076661cd685ae")
                 .unwrap(),
@@ -650,7 +652,8 @@ mod tests {
         let sk: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/src/client.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/client.rs
@@ -96,7 +96,7 @@ impl APIchildkeyCreator {
             let client_secret_share =
                 Zeroizing::<Secp256k1Scalar>::new(random.invert() * secret_key.deref());
             // server's secret share is set to random * 1
-            let mut server_secret_share = random.to_big_int();
+            let mut server_secret_share = random.to_bigint();
             let public_key =
                 publickey_from_secretkey(&self.secret_key, curve).expect("Invalid curve");
             let server_secret_share_encrypted =
@@ -105,7 +105,7 @@ impl APIchildkeyCreator {
             Ok(APIchildkey {
                 paillier_pk: self.paillier_pk.unwrap(),
                 public_key,
-                client_secret_share: client_secret_share.to_big_int(),
+                client_secret_share: client_secret_share.to_bigint(),
                 server_secret_share_encrypted,
             })
         } else if curve == Curve::Secp256r1 {
@@ -115,7 +115,7 @@ impl APIchildkeyCreator {
             let client_secret_share =
                 Zeroizing::<Secp256r1Scalar>::new(random.invert() * secret_key.deref());
             // server's secret share is set to random * 1
-            let mut server_secret_share = random.to_big_int();
+            let mut server_secret_share = random.to_bigint();
             let public_key =
                 publickey_from_secretkey(&self.secret_key, curve).expect("Invalid curve");
             let server_secret_share_encrypted =
@@ -124,7 +124,7 @@ impl APIchildkeyCreator {
             Ok(APIchildkey {
                 paillier_pk: self.paillier_pk.unwrap(),
                 public_key,
-                client_secret_share: client_secret_share.to_big_int(),
+                client_secret_share: client_secret_share.to_bigint(),
                 server_secret_share_encrypted,
             })
         } else {
@@ -157,7 +157,7 @@ pub fn compute_presig(
             Err(_) => return Err(()),
         };
         q = Secp256k1Scalar::q();
-        rx = r_point.x_coor().unwrap().mod_floor(&q);
+        rx = r_point.x_coor().mod_floor(&q);
     } else if curve == Curve::Secp256r1 {
         // get and remove random value r and k from rpool
         let mut pool_entry = match RPOOL_SECP256R1.lock().unwrap().pop() {
@@ -172,7 +172,7 @@ pub fn compute_presig(
             Err(_) => return Err(()),
         };
         q = Secp256r1Scalar::q();
-        rx = r_point.x_coor().unwrap().mod_floor(&q);
+        rx = r_point.x_coor().mod_floor(&q);
     } else {
         return Err(());
     }
@@ -263,22 +263,22 @@ pub fn fill_rpool_secp256r1(
     #[cfg(feature = "wasm")]
     for i in 0..own_dh_secrets.len() {
         let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].get_element())
-            .bytes_compressed_to_big_int();
+            .scalar_mul(&own_dh_secrets[i].fe)
+            .to_bigint();
         RPOOL_SECP256R1
             .lock()
             .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_big_int()));
+            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
     }
     #[cfg(not(feature = "wasm"))]
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
         let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].get_element())
-            .bytes_compressed_to_big_int();
+            .scalar_mul(&own_dh_secrets[i].fe)
+            .to_bigint();
         RPOOL_SECP256R1
             .lock()
             .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_big_int()));
+            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
     });
     for i in &mut own_dh_secrets {
         i.zeroize();
@@ -300,22 +300,22 @@ pub fn fill_rpool_secp256k1(
     #[cfg(feature = "wasm")]
     for i in 0..own_dh_secrets.len() {
         let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].get_element())
-            .bytes_compressed_to_big_int();
+            .scalar_mul(&own_dh_secrets[i].fe)
+            .to_bigint();
         RPOOL_SECP256K1
             .lock()
             .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_big_int()));
+            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
     }
     #[cfg(not(feature = "wasm"))]
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
         let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].get_element())
-            .bytes_compressed_to_big_int();
+            .scalar_mul(&own_dh_secrets[i].fe)
+            .to_bigint();
         RPOOL_SECP256K1
             .lock()
             .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_big_int()));
+            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
     });
     for i in &mut own_dh_secrets {
         i.zeroize();
@@ -634,7 +634,7 @@ mod tests {
         assert!(verify(
             &signature.0,
             &signature.1,
-            &publickey_from_secretkey(&sk.to_big_int(), Curve::Secp256k1).unwrap(),
+            &publickey_from_secretkey(&sk.to_bigint(), Curve::Secp256k1).unwrap(),
             &msg_hash,
             Curve::Secp256k1
         ));

--- a/mpc-wallet/mpc-wallet-lib/src/client.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/client.rs
@@ -637,7 +637,6 @@ mod tests {
             &publickey_from_secretkey(&sk.to_big_int(), Curve::Secp256k1).unwrap(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 }

--- a/mpc-wallet/mpc-wallet-lib/src/client.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/client.rs
@@ -90,11 +90,23 @@ impl APIchildkeyCreator {
             None => return Err(()),
         };
         if curve == Curve::Secp256k1 {
-            let random = Zeroizing::<Secp256k1Scalar>::new(Secp256k1Scalar::new_random());
+            let random = match Secp256k1Scalar::new_random() {
+                Ok(v) => Zeroizing::<Secp256k1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
             // client's secret share is set to the full secret key
-            let secret_key = Zeroizing::<Secp256k1Scalar>::new(ECScalar::from(&self.secret_key));
-            let client_secret_share =
-                Zeroizing::<Secp256k1Scalar>::new(random.invert() * secret_key.deref());
+            let secret_key = match ECScalar::from(&self.secret_key) {
+                Ok(v) => Zeroizing::<Secp256k1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
+            let rand_inv = match random.invert() {
+                Ok(v) => v,
+                Err(_) => return Err(()),
+            };
+            let client_secret_share = match rand_inv * secret_key.deref() {
+                Ok(v) => Zeroizing::<Secp256k1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
             // server's secret share is set to random * 1
             let mut server_secret_share = random.to_bigint();
             let public_key =
@@ -109,11 +121,23 @@ impl APIchildkeyCreator {
                 server_secret_share_encrypted,
             })
         } else if curve == Curve::Secp256r1 {
-            let random = Zeroizing::<Secp256r1Scalar>::new(Secp256r1Scalar::new_random());
+            let random = match Secp256r1Scalar::new_random() {
+                Ok(v) => Zeroizing::<Secp256r1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
             // client's secret share is set to the full secret key
-            let secret_key = Zeroizing::<Secp256r1Scalar>::new(ECScalar::from(&self.secret_key));
-            let client_secret_share =
-                Zeroizing::<Secp256r1Scalar>::new(random.invert() * secret_key.deref());
+            let secret_key = match ECScalar::from(&self.secret_key) {
+                Ok(v) => Zeroizing::<Secp256r1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
+            let rand_inv = match random.invert() {
+                Ok(v) => v,
+                Err(_) => return Err(()),
+            };
+            let client_secret_share = match rand_inv * secret_key.deref() {
+                Ok(v) => Zeroizing::<Secp256r1Scalar>::new(v),
+                Err(_) => return Err(()),
+            };
             // server's secret share is set to random * 1
             let mut server_secret_share = random.to_bigint();
             let public_key =
@@ -262,23 +286,23 @@ pub fn fill_rpool_secp256r1(
     // sequentially for wasm, else parallel
     #[cfg(feature = "wasm")]
     for i in 0..own_dh_secrets.len() {
-        let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].fe)
-            .to_bigint();
-        RPOOL_SECP256R1
-            .lock()
-            .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
+        match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
+            Ok(r) => RPOOL_SECP256R1
+                        .lock()
+                        .unwrap()
+                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+            Err(_) => None,
+        };
     }
     #[cfg(not(feature = "wasm"))]
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
-        let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].fe)
-            .to_bigint();
-        RPOOL_SECP256R1
-            .lock()
-            .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
+        match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
+            Ok(r) => RPOOL_SECP256R1
+                        .lock()
+                        .unwrap()
+                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+            Err(_) => None,
+        };
     });
     for i in &mut own_dh_secrets {
         i.zeroize();
@@ -299,23 +323,23 @@ pub fn fill_rpool_secp256k1(
     // sequentially for wasm, else parallel
     #[cfg(feature = "wasm")]
     for i in 0..own_dh_secrets.len() {
-        let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].fe)
-            .to_bigint();
-        RPOOL_SECP256K1
-            .lock()
-            .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
+        match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
+            Ok(r) => RPOOL_SECP256K1
+                        .lock()
+                        .unwrap()
+                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+            Err(_) => None,
+        };
     }
     #[cfg(not(feature = "wasm"))]
     (0..own_dh_secrets.len()).into_par_iter().for_each(|i| {
-        let r = other_dh_publics[i]
-            .scalar_mul(&own_dh_secrets[i].fe)
-            .to_bigint();
-        RPOOL_SECP256K1
-            .lock()
-            .unwrap()
-            .insert(r, (Utc::now(), own_dh_secrets[i].to_bigint()));
+        match other_dh_publics[i].scalar_mul(&own_dh_secrets[i].fe) {
+            Ok(r) => RPOOL_SECP256K1
+                        .lock()
+                        .unwrap()
+                        .insert(r.to_bigint(), (Utc::now(), own_dh_secrets[i].to_bigint())),
+            Err(_) => None,
+        };
     });
     for i in &mut own_dh_secrets {
         i.zeroize();
@@ -529,7 +553,7 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("8ea92bf3aa6f4ec4939b0888cd71dc6dc113f9cafe571c0bb501c8c9004bb47c")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("34bfa8dd79ff0777e32b89f22a19623ff4fe6fe63aaeb3e2d165fc12cbb2471db")
                 .unwrap(),
@@ -574,7 +598,7 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("EAB592977DF1A8E7D77DB58F4DAE73C860920D28B763A0737217D3793563D53E")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2366a21b029c2e4d627ac5f7e94769ed1b28727f2403b54c8deb076661cd685ae")
                 .unwrap(),
@@ -626,7 +650,7 @@ mod tests {
         let sk: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
                 .unwrap(),
-        );
+        ).unwrap();
         let msg_hash =
             BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/src/client.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/client.rs
@@ -5,7 +5,10 @@
 use crate::common::{
     correct_key_proof_rho, publickey_from_secretkey, CorrectKeyProof, Curve, CORRECT_KEY_M,
 };
+#[cfg(feature = "secp256k1")]
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+#[cfg(feature = "k256")]
+use crate::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
 use chrono::prelude::{DateTime, Utc};
@@ -383,11 +386,6 @@ pub fn encrypt_secret_share(paillier_pk: &EncryptionKey, server_secret_share: &B
     server_encrypted_secret_share
 }
 
-/// sign() is not needed for MPC but used as a faster replacement for the JS implementation
-pub fn sign(secret_key: &Secp256k1Scalar, msg_hash: &BigInt) -> (BigInt, BigInt) {
-    secret_key.clone().sign(&msg_hash)
-}
-
 /// verify proof of correct paillier key generation
 /// see paper "Efficient Noninteractive Certification of RSA Moduli and Beyond" by Goldberg et al. 2019 Section 3.2 and Appendix C.4
 fn verify_correct_key_proof(correct_key_proof: &CorrectKeyProof, n: &BigInt) -> Result<(), ()> {
@@ -420,10 +418,13 @@ mod tests {
     use crate::client::POOL_PAILLIER;
     use crate::client::{
         compute_presig, encrypt_secret_share, fill_rpool_secp256k1, fill_rpool_secp256r1,
-        get_rpool_size, sign, verify_correct_key_proof, APIchildkeyCreator,
+        get_rpool_size, verify_correct_key_proof, APIchildkeyCreator,
     };
-    use crate::common::{publickey_from_secretkey, verify, CorrectKeyProof, Curve};
+    use crate::common::{CorrectKeyProof, Curve};
+    #[cfg(feature = "secp256k1")]
     use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+    #[cfg(feature = "k256")]
+    use crate::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
     use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
     use crate::curves::traits::ECScalar;
     use paillier_common::{EncryptionKey, MinimalEncryptionKey};
@@ -595,7 +596,6 @@ mod tests {
         let _shared = PAILLIER_POOL_LOCK.lock();
         let paillier_pk = EncryptionKey::from(MinimalEncryptionKey{n: BigInt::from_hex("9e2f24f407914eff43b7c7df083c5cc9765c05386485e9e9aa55e7b039290300ba39e86f399e2b338fad4bb34a4d7a7a0cd14fd28503eeebb73ff38e8164616942113afadaeaba525bd4cfdafc4ddd3b012d3fbcd9f276acbad4379b8b93bc4f4d6ddc0a2b9af36b34771595f0e6cb62987b961d83f49ba6ec4b088a1350b3dbbea3e21033801f6c4b212ecd830b5b81075effd06b47feecf18f3c9093662c918073dd95a525b4f99478512ea3bf085993c9bf65922d42b65b338431711dddb5491c2004548df31ab6092ec58db564c8a88a309b0f734171de1f8f4361d5f883e38d5bf519dc347036910aec3c80f2058fa8945c38787094f3450774e2b23129").unwrap()});
         assert_eq!(get_rpool_size(Curve::Secp256r1).unwrap(), 0);
-        //assert_eq!(POOL_PAILLIER.lock().unwrap().len(), 0);
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("EAB592977DF1A8E7D77DB58F4DAE73C860920D28B763A0737217D3793563D53E")
                 .unwrap(),
@@ -610,7 +610,6 @@ mod tests {
         let dh_public_vec = vec![dh_public];
         fill_rpool_secp256r1(dh_secret_vec.clone(), &dh_public_vec, &paillier_pk).unwrap();
         assert_eq!(get_rpool_size(Curve::Secp256r1).unwrap(), 1);
-        //assert_eq!(POOL_PAILLIER.lock().unwrap().len(), 1);
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -628,12 +627,9 @@ mod tests {
             BigInt::from_hex("306978b9dd8d1438387f3e1e58ecec203c61ac0c848834ed094ebef5547b74fda")
                 .unwrap()
         );
-        //assert_eq!(POOL_PAILLIER.lock().unwrap().len(), 0);
         fill_rpool_secp256r1(dh_secret_vec.clone(), &dh_public_vec, &paillier_pk).unwrap();
-        //assert_eq!(POOL_PAILLIER.lock().unwrap().len(), 1);
         let (presig2, _) = compute_presig(&api_childkey, &msg_hash, Curve::Secp256r1).unwrap();
         assert_ne!(presig1, presig2);
-        //assert_eq!(POOL_PAILLIER.lock().unwrap().len(), 0);
     }
 
     #[test]
@@ -645,25 +641,5 @@ mod tests {
         let secret_share_encrypted1 = encrypt_secret_share(&paillier_pk, &secret_key);
         let secret_share_encrypted2 = encrypt_secret_share(&paillier_pk, &secret_key);
         assert_ne!(secret_share_encrypted1, secret_share_encrypted2);
-    }
-
-    #[test]
-    fn test_sign() {
-        let sk: Secp256k1Scalar = ECScalar::from(
-            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
-                .unwrap(),
-        )
-        .unwrap();
-        let msg_hash =
-            BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
-                .unwrap();
-        let signature = sign(&sk, &msg_hash);
-        assert!(verify(
-            &signature.0,
-            &signature.1,
-            &publickey_from_secretkey(&sk.to_bigint(), Curve::Secp256k1).unwrap(),
-            &msg_hash,
-            Curve::Secp256k1
-        ));
     }
 }

--- a/mpc-wallet/mpc-wallet-lib/src/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/common.rs
@@ -99,7 +99,7 @@ pub fn verify(
         let e_fe: Secp256k1Scalar = ECScalar::from(&msg_hash.mod_floor(&q));
         let u1 = Secp256k1Point::generator() * &e_fe * &s_inv_fe;
         let u2 = pk * &rx_fe * &s_inv_fe;
-        u1_plus_u2 = (u1 + u2).x_coor().unwrap();
+        u1_plus_u2 = (u1 + u2).x_coor();
     } else if curve == Curve::Secp256r1 {
         let pk = match Secp256r1Point::from_bytes(&pk_vec) {
             Ok(v) => v,
@@ -112,7 +112,7 @@ pub fn verify(
         let e_fe: Secp256r1Scalar = ECScalar::from(&msg_hash.mod_floor(&q));
         let u1 = Secp256r1Point::generator() * &e_fe * &s_inv_fe;
         let u2 = pk * &rx_fe * &s_inv_fe;
-        u1_plus_u2 = (u1 + u2).x_coor().unwrap();
+        u1_plus_u2 = (u1 + u2).x_coor();
     } else {
         return false;
     }
@@ -129,12 +129,12 @@ pub fn publickey_from_secretkey(secret_key_int: &BigInt, curve: Curve) -> Result
         let base: Secp256k1Point = ECPoint::generator();
         let pk = base * secret_key.deref();
         Ok("0".to_string()
-            + &BigInt::from_bytes(&pk.get_element().serialize_uncompressed()).to_str_radix(16))
+            + &BigInt::from_bytes(&pk.ge.serialize_uncompressed()).to_str_radix(16))
     } else if curve == Curve::Secp256r1 {
         let secret_key = Zeroizing::<Secp256r1Scalar>::new(ECScalar::from(secret_key_int));
         let pk = Secp256r1Point::generator() * secret_key.deref();
         let mut b: [u8; 2 * MODBYTES as usize + 1] = [0; 2 * MODBYTES as usize + 1];
-        pk.get_element().tobytes(&mut b, false);
+        pk.ge.tobytes(&mut b, false);
         let mut s = String::new();
         for byte in b.iter() {
             s += &format!("{:02x}", byte);
@@ -322,7 +322,7 @@ mod tests {
         assert!(verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256k1
         ));
@@ -348,7 +348,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256k1
         ));
@@ -374,7 +374,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256k1
         ));
@@ -400,7 +400,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256k1
         ));
@@ -447,7 +447,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256k1
         ));
@@ -473,7 +473,7 @@ mod tests {
         assert!(verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256r1
         ));
@@ -499,7 +499,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256r1
         ));
@@ -525,7 +525,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256r1
         ));
@@ -551,7 +551,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256r1
         ));
@@ -598,7 +598,7 @@ mod tests {
         assert!(!verify(
             &r,
             &s,
-            &pubkey.bytes_compressed_to_big_int().to_hex(),
+            &pubkey.to_bigint().to_hex(),
             &msg_hash,
             Curve::Secp256r1
         ));

--- a/mpc-wallet/mpc-wallet-lib/src/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/common.rs
@@ -79,7 +79,7 @@ pub fn verify(
     msg_hash: &BigInt,
     curve: Curve,
 ) -> bool{
-    // convert pubkey string format as used by ME to Secp256k1Point
+    // convert pubkey string format as used by ME to bigint
     let pk_int = match BigInt::from_hex(pubkey_str) {
         Ok(v) => v,
         Err(_) => return false,

--- a/mpc-wallet/mpc-wallet-lib/src/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/common.rs
@@ -78,11 +78,11 @@ pub fn verify(
     pubkey_str: &str,
     msg_hash: &BigInt,
     curve: Curve,
-) -> Result<bool, ()> {
+) -> bool{
     // convert pubkey string format as used by ME to Secp256k1Point
     let pk_int = match BigInt::from_hex(pubkey_str) {
         Ok(v) => v,
-        Err(_) => return Err(()),
+        Err(_) => return false,
     };
     let pk_vec = BigInt::to_vec(&pk_int);
     let q: BigInt;
@@ -90,7 +90,7 @@ pub fn verify(
     if curve == Curve::Secp256k1 {
         let pk = match Secp256k1Point::from_bytes(&pk_vec) {
             Ok(v) => v,
-            Err(_) => return Err(()),
+            Err(_) => return false,
         };
         let s_fe: Secp256k1Scalar = ECScalar::from(&s);
         let rx_fe: Secp256k1Scalar = ECScalar::from(&r);
@@ -103,7 +103,7 @@ pub fn verify(
     } else if curve == Curve::Secp256r1 {
         let pk = match Secp256r1Point::from_bytes(&pk_vec) {
             Ok(v) => v,
-            Err(_) => return Err(()),
+            Err(_) => return false,
         };
         let s_fe: Secp256r1Scalar = ECScalar::from(&s);
         let rx_fe: Secp256r1Scalar = ECScalar::from(&r);
@@ -114,12 +114,12 @@ pub fn verify(
         let u2 = pk * &rx_fe * &s_inv_fe;
         u1_plus_u2 = (u1 + u2).x_coor().unwrap();
     } else {
-        return Err(());
+        return false;
     }
     let rx_bytes = &BigInt::to_vec(&r)[..];
     let u1_plus_u2_bytes = &BigInt::to_vec(&u1_plus_u2)[..];
     // second condition is against malleability
-    Ok(rx_bytes.ct_eq(&u1_plus_u2_bytes).unwrap_u8() == 1 && s < &(q - s.clone()))
+    rx_bytes.ct_eq(&u1_plus_u2_bytes).unwrap_u8() == 1 && s < &(q - s.clone())
 }
 
 /// derive public key from secret key, in uncompressed format as expected by ME
@@ -325,8 +325,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -352,8 +351,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -379,8 +377,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -406,8 +403,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -428,8 +424,7 @@ mod tests {
             &"1234567890".to_string(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -455,8 +450,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -482,8 +476,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256r1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -509,8 +502,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256r1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -536,8 +528,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256r1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -563,8 +554,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256r1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -585,8 +575,7 @@ mod tests {
             &"1234567890".to_string(),
             &msg_hash,
             Curve::Secp256k1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]
@@ -612,8 +601,7 @@ mod tests {
             &pubkey.bytes_compressed_to_big_int().to_hex(),
             &msg_hash,
             Curve::Secp256r1
-        )
-        .unwrap());
+        ));
     }
 
     #[test]

--- a/mpc-wallet/mpc-wallet-lib/src/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/common.rs
@@ -5,7 +5,8 @@
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
-use amcl::nist256::big::MODBYTES;
+use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::{AffinePoint, EncodedPoint};
 use rust_bigint::traits::{Converter, NumberTests};
 use rust_bigint::BigInt;
 use lazy_static::__Deref;
@@ -215,14 +216,15 @@ pub fn publickey_from_secretkey(secret_key_int: &BigInt, curve: Curve) -> Result
             Ok(v) => v,
             Err(_) => return Err(()),
         };
-        let mut b: [u8; 2 * MODBYTES as usize + 1] = [0; 2 * MODBYTES as usize + 1];
-        pk.ge.tobytes(&mut b, false);
-        let mut s = String::new();
-        for byte in b.iter() {
-            s += &format!("{:02x}", byte);
+        let tmp = AffinePoint::from_encoded_point(&EncodedPoint::from(&pk.ge));
+        if bool::from(tmp.is_none()) {
+            return Err(())
         }
         // add leading zeros if necessary
-        Ok(format!("{:0>66}", s))
+        Ok(format!(
+            "{:0>130}",
+            BigInt::from_bytes(&tmp.unwrap().to_encoded_point(false).as_bytes()).to_hex()
+        ))
     } else {
         Err(())
     }

--- a/mpc-wallet/mpc-wallet-lib/src/common.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/common.rs
@@ -5,13 +5,13 @@
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
+use lazy_static::__Deref;
+#[cfg(feature = "num_bigint")]
+use num_integer::Integer;
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256::{AffinePoint, EncodedPoint};
 use rust_bigint::traits::{Converter, NumberTests};
 use rust_bigint::BigInt;
-use lazy_static::__Deref;
-#[cfg(feature = "num_bigint")]
-use num_integer::Integer;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
@@ -85,13 +85,7 @@ pub fn dh_init_secp256k1(n: usize) -> Result<(Vec<Secp256k1Scalar>, Vec<Secp256k
 }
 
 /// verify an ECDSA signature
-pub fn verify(
-    r: &BigInt,
-    s: &BigInt,
-    pubkey_str: &str,
-    msg_hash: &BigInt,
-    curve: Curve,
-) -> bool{
+pub fn verify(r: &BigInt, s: &BigInt, pubkey_str: &str, msg_hash: &BigInt, curve: Curve) -> bool {
     // convert pubkey string format as used by ME to bigint
     let pk_int = match BigInt::from_hex(pubkey_str) {
         Ok(v) => v,
@@ -205,8 +199,7 @@ pub fn publickey_from_secretkey(secret_key_int: &BigInt, curve: Curve) -> Result
             Ok(v) => v,
             Err(_) => return Err(()),
         };
-        Ok("0".to_string()
-            + &BigInt::from_bytes(&pk.ge.serialize_uncompressed()).to_str_radix(16))
+        Ok("0".to_string() + &BigInt::from_bytes(&pk.ge.serialize_uncompressed()).to_str_radix(16))
     } else if curve == Curve::Secp256r1 {
         let secret_key = match ECScalar::from(secret_key_int) {
             Ok(v) => Zeroizing::<Secp256r1Scalar>::new(v),
@@ -218,7 +211,7 @@ pub fn publickey_from_secretkey(secret_key_int: &BigInt, curve: Curve) -> Result
         };
         let tmp = AffinePoint::from_encoded_point(&EncodedPoint::from(&pk.ge));
         if bool::from(tmp.is_none()) {
-            return Err(())
+            return Err(());
         }
         // add leading zeros if necessary
         Ok(format!(
@@ -313,10 +306,10 @@ mod tests {
     use crate::curves::secp256_k1::Secp256k1Point;
     use crate::curves::secp256_r1::Secp256r1Point;
     use crate::curves::traits::ECPoint;
-    use rust_bigint::traits::Converter;
-    use rust_bigint::BigInt;
     #[cfg(feature = "num_bigint")]
     use num_traits::Num;
+    use rust_bigint::traits::Converter;
+    use rust_bigint::BigInt;
 
     #[test]
     // Test Vectors taken from:
@@ -399,7 +392,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("721c7dde8df4a6d06c2bea91dc6e9c075c3c35926d73f891788b9ae681b7eed5")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("0000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -425,7 +419,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("721c7dde8df4a6d06c2bea91dc6e9c075c3c35926d73f891788b9ae681b7eed5")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("0000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -451,7 +446,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("721c7dde8df4a6d06c2bea91dc6e9c075c3c35926d73f891788b9ae681b7eed5")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("0000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -477,7 +473,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("2b3b5e8491a48ff6e1620732579807916eeb07beb6f9970dc5952bd444404f74")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("0000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -524,7 +521,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("721c7dde8df4a6d06c2bea91dc6e9c075c3c35926d73f891788b9ae681b7eed5")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("1000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -550,7 +548,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("dcf1956f7877ffb5c927e5d3e479fe913e10a0caa7a34866fe44f8bddf4b0a04")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -576,7 +575,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("dcf1956f7877ffb5c927e5d3e479fe913e10a0caa7a34866fe44f8bddf4b0a04")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -602,7 +602,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("dcf1956f7877ffb5c927e5d3e479fe913e10a0caa7a34866fe44f8bddf4b0a04")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -628,7 +629,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("a8b5559fa5b697360dc7633f7782fd9f1ec4ba090dc362fd79ee7e6313d755a4")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -675,7 +677,8 @@ mod tests {
                 .unwrap(),
             &BigInt::from_hex("dcf1956f7877ffb5c927e5d3e479fe913e10a0caa7a34866fe44f8bddf4b0a04")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/src/curves/mod.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "secp256k1")]
 pub mod secp256_k1;
+#[cfg(feature = "k256")]
+pub mod secp256_k1_rust;
+
 pub mod secp256_r1;
 pub mod traits;

--- a/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1.rs
@@ -2,12 +2,9 @@
 // based on MIT/Apache-licensed https://github.com/KZen-networks/curv/blob/master/src/elliptic/curves/secp256_k1.rs
 
 use super::traits::{ECPoint, ECScalar};
-use crate::ErrorKey;
 use rust_bigint::traits::{Converter, Modulo};
 use rust_bigint::BigInt;
 use getrandom::getrandom;
-#[cfg(feature = "num_bigint")]
-use num_traits::Num;
 use secp256k1::constants::{
     COMPACT_SIGNATURE_SIZE, CURVE_ORDER, GENERATOR_X, GENERATOR_Y, MESSAGE_SIZE, SECRET_KEY_SIZE,
     UNCOMPRESSED_PUBLIC_KEY_SIZE,
@@ -23,23 +20,17 @@ use std::ptr;
 use std::sync::{atomic, Once};
 use zeroize::Zeroize;
 
-pub type SK = SecretKey;
-pub type PK = PublicKey;
-
 #[derive(Clone, Debug)]
 pub struct Secp256k1Scalar {
     purpose: &'static str,
-    fe: SK,
+    pub(crate) fe: SecretKey,
 }
 
 #[derive(Clone, Debug, Copy)]
 pub struct Secp256k1Point {
     purpose: &'static str,
-    ge: PK,
+    pub(crate) ge: PublicKey,
 }
-
-pub type GE = Secp256k1Point;
-pub type FE = Secp256k1Scalar;
 
 impl Secp256k1Scalar {
     /// sign() is basically a textbook ECDSA sign function. In contrast to MPC, sign() makes use of RFC6979 (deterministic but still cryptographically secure nonce generation) and produces the same signature given the same secret key and message.
@@ -51,7 +42,7 @@ impl Secp256k1Scalar {
         msg_vec.extend_from_slice(&msg_bytes);
         let msg = Message::from_slice(&msg_vec).unwrap();
         let signature = get_context()
-            .sign(&msg, &self.get_element())
+            .sign(&msg, &self.fe)
             .serialize_compact();
         let r = BigInt::from_bytes(&signature[0..COMPACT_SIGNATURE_SIZE / 2]);
         let s = BigInt::from_bytes(&signature[COMPACT_SIGNATURE_SIZE / 2..COMPACT_SIGNATURE_SIZE]);
@@ -63,51 +54,39 @@ impl Secp256k1Point {
     pub fn random_point() -> Secp256k1Point {
         let random_scalar: Secp256k1Scalar = Secp256k1Scalar::new_random();
         let base_point = Secp256k1Point::generator();
-        let pk = base_point.scalar_mul(&random_scalar.get_element());
+        let pk = base_point.scalar_mul(&random_scalar.fe);
         Secp256k1Point {
             purpose: "random_point",
-            ge: pk.get_element(),
+            ge: pk.ge,
         }
     }
 }
 
 impl Zeroize for Secp256k1Scalar {
     fn zeroize(&mut self) {
-        unsafe { ptr::write_volatile(self, FE::zero()) };
+        let zero = unsafe { std::mem::transmute::<[u8; SECRET_KEY_SIZE], SecretKey>([0u8; SECRET_KEY_SIZE]) };
+        let zero_scalar = Secp256k1Scalar {
+            purpose: "zero",
+            fe: zero,
+        };
+        unsafe { ptr::write_volatile(self, zero_scalar) };
         atomic::fence(atomic::Ordering::SeqCst);
         atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
 
-impl ECScalar<SK> for Secp256k1Scalar {
+impl ECScalar<SecretKey> for Secp256k1Scalar {
     fn new_random() -> Secp256k1Scalar {
         let mut arr = [0u8; 32];
         getrandom(&mut arr).unwrap();
         Secp256k1Scalar {
             purpose: "random",
-            fe: SK::from_slice(&arr[0..arr.len()]).unwrap(),
+            fe: SecretKey::from_slice(&arr[0..arr.len()]).unwrap(),
         }
-    }
-
-    fn zero() -> Secp256k1Scalar {
-        let zero_arr = [0u8; 32];
-        let zero = unsafe { std::mem::transmute::<[u8; 32], SecretKey>(zero_arr) };
-        Secp256k1Scalar {
-            purpose: "zero",
-            fe: zero,
-        }
-    }
-
-    fn get_element(&self) -> SK {
-        self.fe
-    }
-
-    fn set_element(&mut self, element: SK) {
-        self.fe = element
     }
 
     fn from(n: &BigInt) -> Secp256k1Scalar {
-        let curve_order = FE::q();
+        let curve_order = Secp256k1Scalar::q();
         let n_reduced = BigInt::mod_add(n, &BigInt::from(0), &curve_order);
         let mut v = BigInt::to_vec(&n_reduced);
 
@@ -119,11 +98,11 @@ impl ECScalar<SK> for Secp256k1Scalar {
 
         Secp256k1Scalar {
             purpose: "from_big_int",
-            fe: SK::from_slice(&v).unwrap(),
+            fe: SecretKey::from_slice(&v).unwrap(),
         }
     }
 
-    fn to_big_int(&self) -> BigInt {
+    fn to_bigint(&self) -> BigInt {
         BigInt::from_bytes(&(self.fe[0..self.fe.len()]))
     }
 
@@ -131,77 +110,72 @@ impl ECScalar<SK> for Secp256k1Scalar {
         BigInt::from_bytes(&CURVE_ORDER.as_ref())
     }
 
-    fn add(&self, other: &SK) -> Secp256k1Scalar {
-        let mut other_scalar: FE = ECScalar::new_random();
-        other_scalar.set_element(*other);
-        let res: FE = ECScalar::from(&BigInt::mod_add(
-            &self.to_big_int(),
-            &other_scalar.to_big_int(),
-            &FE::q(),
-        ));
+    fn add(&self, other: &SecretKey) -> Secp256k1Scalar {
+        let mut plus = other.clone();
+        plus.add_assign(&self.to_vec()).unwrap();
         Secp256k1Scalar {
             purpose: "add",
-            fe: res.get_element(),
+            fe: plus,
         }
     }
 
-    fn mul(&self, other: &SK) -> Secp256k1Scalar {
-        let mut other_scalar: FE = ECScalar::new_random();
-        other_scalar.set_element(*other);
-        let res: FE = ECScalar::from(&BigInt::mod_mul(
-            &self.to_big_int(),
-            &other_scalar.to_big_int(),
-            &FE::q(),
-        ));
+    fn mul(&self, other: &SecretKey) -> Secp256k1Scalar {
+        let mut mul = other.clone();
+        mul.mul_assign(&self.to_vec()).unwrap();
         Secp256k1Scalar {
             purpose: "mul",
-            fe: res.get_element(),
+            fe: mul,
         }
     }
 
-    fn sub(&self, other: &SK) -> Secp256k1Scalar {
-        let mut other_scalar: FE = ECScalar::new_random();
-        other_scalar.set_element(*other);
-        let res: FE = ECScalar::from(&BigInt::mod_sub(
-            &self.to_big_int(),
-            &other_scalar.to_big_int(),
-            &FE::q(),
-        ));
+    fn sub(&self, other: &SecretKey) -> Secp256k1Scalar {
+        let mut sub = other.clone();
+        sub.negate_assign();
+        sub.add_assign(&self.to_vec()).unwrap();
         Secp256k1Scalar {
             purpose: "sub",
-            fe: res.get_element(),
+            fe: sub,
         }
     }
 
     fn invert(&self) -> Secp256k1Scalar {
-        ECScalar::from(&BigInt::mod_inv(&self.to_big_int(), &FE::q()))
+        ECScalar::from(&BigInt::mod_inv(&self.to_bigint(), &Secp256k1Scalar::q()))
+    }
+
+    /// convert to vector and pad with zeros if necessary
+    fn to_vec(&self) -> Vec<u8> {
+        let vec = BigInt::to_vec(&self.to_bigint());
+        let mut v = vec![0; SECRET_KEY_SIZE - vec.len()];
+        v.extend(&vec);
+        v
     }
 }
+
 impl Mul<Secp256k1Scalar> for Secp256k1Scalar {
     type Output = Secp256k1Scalar;
     fn mul(self, other: Secp256k1Scalar) -> Secp256k1Scalar {
-        (&self).mul(&other.get_element())
+        (&self).mul(&other.fe)
     }
 }
 
 impl<'o> Mul<&'o Secp256k1Scalar> for Secp256k1Scalar {
     type Output = Secp256k1Scalar;
     fn mul(self, other: &'o Secp256k1Scalar) -> Secp256k1Scalar {
-        (&self).mul(&other.get_element())
+        (&self).mul(&other.fe)
     }
 }
 
 impl Add<Secp256k1Scalar> for Secp256k1Scalar {
     type Output = Secp256k1Scalar;
     fn add(self, other: Secp256k1Scalar) -> Secp256k1Scalar {
-        (&self).add(&other.get_element())
+        (&self).add(&other.fe)
     }
 }
 
 impl<'o> Add<&'o Secp256k1Scalar> for Secp256k1Scalar {
     type Output = Secp256k1Scalar;
     fn add(self, other: &'o Secp256k1Scalar) -> Secp256k1Scalar {
-        (&self).add(&other.get_element())
+        (&self).add(&other.fe)
     }
 }
 
@@ -210,7 +184,7 @@ impl Serialize for Secp256k1Scalar {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{:0>64}", self.to_big_int().to_hex()))
+        serializer.serialize_str(&format!("{:0>64}", self.to_bigint().to_hex()))
     }
 }
 
@@ -233,94 +207,74 @@ impl<'de> Visitor<'de> for Secp256k1ScalarVisitor {
     }
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<Secp256k1Scalar, E> {
-        let v = BigInt::from_str_radix(s, 16).expect("Failed in serde");
+        let v = BigInt::from_hex(&s).expect("Failed in serde");
         Ok(ECScalar::from(&v))
     }
 }
 
 impl PartialEq for Secp256k1Scalar {
     fn eq(&self, other: &Secp256k1Scalar) -> bool {
-        self.get_element() == other.get_element()
+        self.fe == other.fe
     }
 }
 
 impl PartialEq for Secp256k1Point {
     fn eq(&self, other: &Secp256k1Point) -> bool {
-        self.get_element() == other.get_element()
+        self.ge == other.ge
     }
 }
 
 impl Zeroize for Secp256k1Point {
     fn zeroize(&mut self) {
-        unsafe { ptr::write_volatile(self, GE::generator()) };
+        unsafe { ptr::write_volatile(self, Secp256k1Point::generator()) };
         atomic::fence(atomic::Ordering::SeqCst);
         atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
 
-impl ECPoint<PK, SK> for Secp256k1Point {
+impl ECPoint<PublicKey, SecretKey> for Secp256k1Point {
     fn generator() -> Secp256k1Point {
         let mut v = vec![4 as u8];
         v.extend(GENERATOR_X.as_ref());
         v.extend(GENERATOR_Y.as_ref());
         Secp256k1Point {
             purpose: "base_fe",
-            ge: PK::from_slice(&v).unwrap(),
+            ge: PublicKey::from_slice(&v).unwrap(),
         }
     }
 
-    fn get_element(&self) -> PK {
-        self.ge
-    }
-
-    // to return from BigInt use from_bigint()
-    fn bytes_compressed_to_big_int(&self) -> BigInt {
+    fn to_bigint(&self) -> BigInt {
         let serial = self.ge.serialize();
         BigInt::from_bytes(&serial[0..33])
     }
 
-    fn x_coor(&self) -> Option<BigInt> {
-        let serialized_pk = PK::serialize_uncompressed(&self.ge);
+    fn x_coor(&self) -> BigInt {
+        let serialized_pk = PublicKey::serialize_uncompressed(&self.ge);
         let x = &serialized_pk[1..=serialized_pk.len() / 2];
-        let x_vec = x.to_vec();
-        Some(BigInt::from_bytes(&x_vec[..]))
+        BigInt::from_bytes(&x.to_vec()[..])
     }
 
-    fn y_coor(&self) -> Option<BigInt> {
-        let serialized_pk = PK::serialize_uncompressed(&self.ge);
+    fn y_coor(&self) -> BigInt {
+        let serialized_pk = PublicKey::serialize_uncompressed(&self.ge);
         let y = &serialized_pk[(serialized_pk.len() - 1) / 2 + 1..serialized_pk.len()];
-        let y_vec = y.to_vec();
-        Some(BigInt::from_bytes(&y_vec[..]))
+        BigInt::from_bytes(&y.to_vec()[..])
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Secp256k1Point, ErrorKey> {
-        let result = PK::from_slice(&bytes);
-        let test = result.map(|pk| Secp256k1Point {
-            purpose: "random",
-            ge: pk,
-        });
-        test.map_err(|_err| ErrorKey::InvalidPublicKey)
+    fn from_bytes(bytes: &[u8]) -> Result<Secp256k1Point, ()> {
+        match PublicKey::from_slice(&bytes) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "random",
+                ge: v,
+            }),
+            Err(_) => return Err(()),
+        }
     }
 
-    fn pk_to_key_slice(&self) -> Vec<u8> {
-        let mut v = vec![4 as u8];
-        let x_vec = BigInt::to_vec(&self.x_coor().unwrap());
-        let y_vec = BigInt::to_vec(&self.y_coor().unwrap());
-
-        let mut raw_x: Vec<u8> = Vec::new();
-        let mut raw_y: Vec<u8> = Vec::new();
-        raw_x.extend(vec![0u8; 32 - x_vec.len()]);
-        raw_x.extend(x_vec);
-
-        raw_y.extend(vec![0u8; 32 - y_vec.len()]);
-        raw_y.extend(y_vec);
-
-        v.extend(raw_x);
-        v.extend(raw_y);
-        v
+    fn to_vec(&self) -> Vec<u8> {
+        self.ge.serialize_uncompressed().to_vec()
     }
 
-    fn scalar_mul(&self, fe: &SK) -> Secp256k1Point {
+    fn scalar_mul(&self, fe: &SecretKey) -> Secp256k1Point {
         let mut new_point = *self;
         new_point
             .ge
@@ -329,80 +283,38 @@ impl ECPoint<PK, SK> for Secp256k1Point {
         new_point
     }
 
-    fn add_point(&self, other: &PK) -> Secp256k1Point {
+    fn add_point(&self, other: &PublicKey) -> Secp256k1Point {
         Secp256k1Point {
             purpose: "combine",
             ge: self.ge.combine(other).unwrap(),
         }
     }
 
-    fn sub_point(&self, other: &PK) -> Secp256k1Point {
-        let point = Secp256k1Point {
-            purpose: "sub_point",
-            ge: *other,
-        };
-        let p: Vec<u8> = vec![
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 255, 255, 252, 47,
-        ];
-        let order = BigInt::from_bytes(&p[..]);
-        let x = point.x_coor().unwrap();
-        let y = point.y_coor().unwrap();
-        let minus_y = BigInt::mod_sub(&order, &y, &order);
-
-        let x_vec = BigInt::to_vec(&x);
-        let y_vec = BigInt::to_vec(&minus_y);
-
-        let mut template_x = vec![0; 32 - x_vec.len()];
-        template_x.extend_from_slice(&x_vec);
-        // 4 indicates uncompressed point format
-        let mut x_vec = vec![4 as u8];
-        x_vec.extend_from_slice(&template_x);
-
-        let mut template_y = vec![0; 32 - y_vec.len()];
-        template_y.extend_from_slice(&y_vec);
-        let y_vec = template_y;
-
-        x_vec.extend_from_slice(&y_vec);
-
-        let minus_point: GE = ECPoint::from_bytes(&x_vec).unwrap();
-        ECPoint::add_point(self, &minus_point.get_element())
+    fn sub_point(&self, other: &PublicKey) -> Secp256k1Point {
+        let mut minus = other.clone();
+        minus.negate_assign(get_context());
+        self.add_point(&minus)
     }
 
     fn from_coor(x: &BigInt, y: &BigInt) -> Secp256k1Point {
-        let mut vec_x = BigInt::to_vec(x);
-        let mut vec_y = BigInt::to_vec(y);
-        let coor_size = (UNCOMPRESSED_PUBLIC_KEY_SIZE - 1) / 2;
-
-        if vec_x.len() < coor_size {
-            // pad
-            let mut x_buffer = vec![0; coor_size - vec_x.len()];
-            x_buffer.extend_from_slice(&vec_x);
-            vec_x = x_buffer
-        }
-
-        if vec_y.len() < coor_size {
-            // pad
-            let mut y_buffer = vec![0; coor_size - vec_y.len()];
-            y_buffer.extend_from_slice(&vec_y);
-            vec_y = y_buffer
-        }
-
-        assert_eq!(x, &BigInt::from_bytes(vec_x.as_ref()));
-        assert_eq!(y, &BigInt::from_bytes(vec_y.as_ref()));
-
+        const COOR_SIZE: usize = (UNCOMPRESSED_PUBLIC_KEY_SIZE - 1) / 2;
         let mut v = vec![4 as u8];
+        let vec_x = BigInt::to_vec(x);
+        // pad with zeros if necessary
+        v.extend_from_slice(&vec![0; COOR_SIZE - vec_x.len()]);
         v.extend(vec_x);
+        let vec_y = BigInt::to_vec(y);
+        // pad with zeros if necessary
+        v.extend_from_slice(&vec![0; COOR_SIZE - vec_y.len()]);
         v.extend(vec_y);
-
         Secp256k1Point {
             purpose: "base_fe",
-            ge: PK::from_slice(&v).unwrap(),
+            ge: PublicKey::from_slice(&v).unwrap(),
         }
     }
 
     fn to_hex(&self) -> String {
-        format!("{:0>66}", self.bytes_compressed_to_big_int().to_hex())
+        format!("{:0>66}", self.to_bigint().to_hex())
     }
 
     fn from_hex(s: &str) -> Result<Secp256k1Point, ()> {
@@ -415,25 +327,6 @@ impl ECPoint<PK, SK> for Secp256k1Point {
             Err(_) => return Err(()),
         };
         Ok(point)
-    }
-}
-
-impl From<String> for Secp256k1Point {
-    fn from(str_point: String) -> Self {
-        let bigint = BigInt::from_str_radix(&str_point, 16).unwrap();
-        Secp256k1Point::from_bigint(&bigint).unwrap()
-    }
-}
-
-impl Into<String> for &Secp256k1Point {
-    fn into(self) -> String {
-        let bigint = self.bytes_compressed_to_big_int();
-        let hex = bigint.to_str_radix(16);
-        if hex.len() % 2 == 0 {
-            hex
-        } else {
-            format!("0{}", &hex)
-        }
     }
 }
 
@@ -461,42 +354,42 @@ pub fn get_context() -> &'static Secp256k1<All> {
 impl Mul<Secp256k1Scalar> for Secp256k1Point {
     type Output = Secp256k1Point;
     fn mul(self, other: Secp256k1Scalar) -> Self::Output {
-        self.scalar_mul(&other.get_element())
+        self.scalar_mul(&other.fe)
     }
 }
 
 impl<'o> Mul<&'o Secp256k1Scalar> for Secp256k1Point {
     type Output = Secp256k1Point;
     fn mul(self, other: &'o Secp256k1Scalar) -> Self::Output {
-        self.scalar_mul(&other.get_element())
+        self.scalar_mul(&other.fe)
     }
 }
 
 impl<'o> Mul<&'o Secp256k1Scalar> for &'o Secp256k1Point {
     type Output = Secp256k1Point;
     fn mul(self, other: &'o Secp256k1Scalar) -> Self::Output {
-        self.scalar_mul(&other.get_element())
+        self.scalar_mul(&other.fe)
     }
 }
 
 impl Add<Secp256k1Point> for Secp256k1Point {
     type Output = Secp256k1Point;
     fn add(self, other: Secp256k1Point) -> Self::Output {
-        self.add_point(&other.get_element())
+        self.add_point(&other.ge)
     }
 }
 
 impl<'o> Add<&'o Secp256k1Point> for Secp256k1Point {
     type Output = Secp256k1Point;
     fn add(self, other: &'o Secp256k1Point) -> Self::Output {
-        self.add_point(&other.get_element())
+        self.add_point(&other.ge)
     }
 }
 
 impl<'o> Add<&'o Secp256k1Point> for &'o Secp256k1Point {
     type Output = Secp256k1Point;
     fn add(self, other: &'o Secp256k1Point) -> Self::Output {
-        self.add_point(&other.get_element())
+        self.add_point(&other.ge)
     }
 }
 
@@ -543,8 +436,7 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
 
 #[cfg(test)]
 mod tests {
-    use super::{BigInt, ErrorKey, Secp256k1Point, Secp256k1Scalar};
-    use crate::curves::secp256_k1::{FE, GE};
+    use super::{BigInt, Secp256k1Point, Secp256k1Scalar};
     use crate::curves::traits::{ECPoint, ECScalar};
     use rust_bigint::traits::{Converter, Modulo};
     use bincode;
@@ -587,10 +479,10 @@ mod tests {
         Secp256k1Point::from_coor(&x, &y); // x and y not of size 32 each
 
         let r = Secp256k1Point::random_point();
-        let r_expected = Secp256k1Point::from_coor(&r.x_coor().unwrap(), &r.y_coor().unwrap());
+        let r_expected = Secp256k1Point::from_coor(&r.x_coor(), &r.y_coor());
 
-        assert_eq!(r.x_coor().unwrap(), r_expected.x_coor().unwrap());
-        assert_eq!(r.y_coor().unwrap(), r_expected.y_coor().unwrap());
+        assert_eq!(r.x_coor(), r_expected.x_coor());
+        assert_eq!(r.y_coor(), r_expected.y_coor());
     }
 
     #[test]
@@ -608,7 +500,7 @@ mod tests {
         let pk = Secp256k1Point::generator();
         let s = serde_json::to_string(&pk).expect("Failed in serialization");
         let expected =
-            serde_json::to_string(&("0".to_string() + &pk.bytes_compressed_to_big_int().to_hex()))
+            serde_json::to_string(&("0".to_string() + &pk.to_bigint().to_hex()))
                 .expect("Failed in serialization");
         assert_eq!(s, expected);
         let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in serialization");
@@ -625,28 +517,28 @@ mod tests {
 
     #[test]
     fn test_serdes_pk() {
-        let pk = GE::generator();
+        let pk = Secp256k1Point::generator();
         let s = serde_json::to_string(&pk).expect("Failed in serialization");
-        let des_pk: GE = serde_json::from_str(&s).expect("Failed in deserialization");
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in deserialization");
         assert_eq!(des_pk, pk);
     }
 
     #[test]
     #[should_panic]
     fn test_serdes_bad_pk() {
-        let pk = GE::generator();
+        let pk = Secp256k1Point::generator();
         let s = serde_json::to_string(&pk).expect("Failed in serialization");
         // we make sure that the string encodes invalid point:
         let s: String = s.replace("79be", "79bf");
-        let des_pk: GE = serde_json::from_str(&s).expect("Failed in deserialization");
-        assert_eq!(des_pk.get_element(), pk.get_element());
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in deserialization");
+        assert_eq!(des_pk.ge, pk.ge);
     }
 
     #[test]
+    #[should_panic]
     fn test_from_bytes() {
         let vec = BigInt::to_vec(&BigInt::from(1337));
-        let result = Secp256k1Point::from_bytes(&vec);
-        assert_eq!(result.unwrap_err(), ErrorKey::InvalidPublicKey)
+        Secp256k1Point::from_bytes(&vec).unwrap();
     }
 
     #[test]
@@ -682,53 +574,53 @@ mod tests {
 
     #[test]
     fn test_minus_point() {
-        let a: FE = ECScalar::new_random();
-        let b: FE = ECScalar::new_random();
-        let b_bn = b.to_big_int();
-        let order = FE::q();
+        let a: Secp256k1Scalar = ECScalar::new_random();
+        let b: Secp256k1Scalar = ECScalar::new_random();
+        let b_bn = b.to_bigint();
+        let order = Secp256k1Scalar::q();
         let minus_b = BigInt::mod_sub(&order, &b_bn, &order);
-        let a_minus_b = BigInt::mod_add(&a.to_big_int(), &minus_b, &order);
-        let a_minus_b_fe: FE = ECScalar::from(&a_minus_b);
-        let base: GE = ECPoint::generator();
+        let a_minus_b = BigInt::mod_add(&a.to_bigint(), &minus_b, &order);
+        let a_minus_b_fe: Secp256k1Scalar = ECScalar::from(&a_minus_b);
+        let base: Secp256k1Point = ECPoint::generator();
         let point_ab1 = base.clone() * a_minus_b_fe;
 
         let point_a = base.clone() * a;
         let point_b = base.clone() * b;
-        let point_ab2 = point_a.sub_point(&point_b.get_element());
-        assert_eq!(point_ab1.get_element(), point_ab2.get_element());
+        let point_ab2 = point_a.sub_point(&point_b.ge);
+        assert_eq!(point_ab1.ge, point_ab2.ge);
     }
 
     #[test]
     fn test_invert() {
-        let a: FE = ECScalar::new_random();
-        let a_bn = a.to_big_int();
+        let a: Secp256k1Scalar = ECScalar::new_random();
+        let a_bn = a.to_bigint();
         let a_inv = a.invert();
-        let a_inv_bn_1 = BigInt::mod_inv(&a_bn, &FE::q());
-        let a_inv_bn_2 = a_inv.to_big_int();
+        let a_inv_bn_1 = BigInt::mod_inv(&a_bn, &Secp256k1Scalar::q());
+        let a_inv_bn_2 = a_inv.to_bigint();
         assert_eq!(a_inv_bn_1, a_inv_bn_2);
     }
 
     #[test]
     fn test_scalar_mul_scalar() {
-        let a: FE = ECScalar::new_random();
-        let b: FE = ECScalar::new_random();
-        let c1 = a.mul(&b.get_element());
+        let a: Secp256k1Scalar = ECScalar::new_random();
+        let b: Secp256k1Scalar = ECScalar::new_random();
+        let c1 = a.mul(&b.fe);
         let c2 = a * b;
-        assert_eq!(c1.get_element(), c2.get_element());
+        assert_eq!(c1.fe, c2.fe);
     }
 
     #[test]
     fn test_pk_to_key_slice() {
         for _ in 1..200 {
-            let r = FE::new_random();
-            let rg = GE::generator() * &r;
-            let key_slice = rg.pk_to_key_slice();
+            let r = Secp256k1Scalar::new_random();
+            let rg = Secp256k1Point::generator() * &r;
+            let key_slice = rg.to_vec();
 
             assert!(key_slice.len() == 65);
             assert!(key_slice[0].clone() == 4);
 
-            let rg_prime: GE = ECPoint::from_bytes(&key_slice).unwrap();
-            assert_eq!(rg_prime.get_element(), rg.get_element());
+            let rg_prime: Secp256k1Point = ECPoint::from_bytes(&key_slice).unwrap();
+            assert_eq!(rg_prime.ge, rg.ge);
         }
     }
 

--- a/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1.rs
@@ -2,9 +2,9 @@
 // based on MIT/Apache-licensed https://github.com/KZen-networks/curv/blob/master/src/elliptic/curves/secp256_k1.rs
 
 use super::traits::{ECPoint, ECScalar};
+use getrandom::getrandom;
 use rust_bigint::traits::{Converter, Modulo};
 use rust_bigint::BigInt;
-use getrandom::getrandom;
 use secp256k1::constants::{
     COMPACT_SIGNATURE_SIZE, CURVE_ORDER, GENERATOR_X, GENERATOR_Y, MESSAGE_SIZE, SECRET_KEY_SIZE,
     UNCOMPRESSED_PUBLIC_KEY_SIZE,
@@ -41,9 +41,7 @@ impl Secp256k1Scalar {
         let mut msg_vec = vec![0; MESSAGE_SIZE - msg_bytes.len()];
         msg_vec.extend_from_slice(&msg_bytes);
         let msg = Message::from_slice(&msg_vec).unwrap();
-        let signature = get_context()
-            .sign(&msg, &self.fe)
-            .serialize_compact();
+        let signature = get_context().sign(&msg, &self.fe).serialize_compact();
         let r = BigInt::from_bytes(&signature[0..COMPACT_SIGNATURE_SIZE / 2]);
         let s = BigInt::from_bytes(&signature[COMPACT_SIGNATURE_SIZE / 2..COMPACT_SIGNATURE_SIZE]);
         (r, s)
@@ -52,7 +50,9 @@ impl Secp256k1Scalar {
 
 impl Zeroize for Secp256k1Scalar {
     fn zeroize(&mut self) {
-        let zero = unsafe { std::mem::transmute::<[u8; SECRET_KEY_SIZE], SecretKey>([0u8; SECRET_KEY_SIZE]) };
+        let zero = unsafe {
+            std::mem::transmute::<[u8; SECRET_KEY_SIZE], SecretKey>([0u8; SECRET_KEY_SIZE])
+        };
         let zero_scalar = Secp256k1Scalar {
             purpose: "zero",
             fe: zero,
@@ -136,10 +136,11 @@ impl ECScalar<SecretKey> for Secp256k1Scalar {
 
     fn invert(&self) -> Result<Secp256k1Scalar, ()> {
         // rust-secp256k1 does not support inverse yet. see https://github.com/rust-bitcoin/rust-secp256k1/issues/181
-        let scalar: Secp256k1Scalar = match ECScalar::from(&BigInt::mod_inv(&self.to_bigint(), &Secp256k1Scalar::q())) {
-            Ok(v) => v,
-            Err(_) => return Err(()),
-        };
+        let scalar: Secp256k1Scalar =
+            match ECScalar::from(&BigInt::mod_inv(&self.to_bigint(), &Secp256k1Scalar::q())) {
+                Ok(v) => v,
+                Err(_) => return Err(()),
+            };
         Ok(scalar)
     }
 
@@ -447,8 +448,8 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
 mod tests {
     use super::{BigInt, Secp256k1Point, Secp256k1Scalar};
     use crate::curves::traits::{ECPoint, ECScalar};
-    use rust_bigint::traits::{Converter, Modulo};
     use bincode;
+    use rust_bigint::traits::{Converter, Modulo};
     use serde_json;
 
     fn random_point() -> Secp256k1Point {
@@ -516,9 +517,8 @@ mod tests {
     fn serialize_pk() {
         let pk = Secp256k1Point::generator();
         let s = serde_json::to_string(&pk).expect("Failed in serialization");
-        let expected =
-            serde_json::to_string(&("0".to_string() + &pk.to_bigint().to_hex()))
-                .expect("Failed in serialization");
+        let expected = serde_json::to_string(&("0".to_string() + &pk.to_bigint().to_hex()))
+            .expect("Failed in serialization");
         assert_eq!(s, expected);
         let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in serialization");
         assert_eq!(des_pk.ge, pk.ge);
@@ -621,7 +621,10 @@ mod tests {
     fn test_scalar_mul() {
         let g = Secp256k1Point::generator();
         let a: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
-        let expected = Secp256k1Point::from_hex("02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5").unwrap();
+        let expected = Secp256k1Point::from_hex(
+            "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+        )
+        .unwrap();
         assert_eq!((g * a).unwrap(), expected);
     }
 
@@ -654,7 +657,8 @@ mod tests {
         let sk: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -678,7 +682,8 @@ mod tests {
         let sk: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("5794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("100000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -702,7 +707,8 @@ mod tests {
         let sk: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("110000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1_rust.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/secp256_k1_rust.rs
@@ -1,0 +1,881 @@
+// Pure Rust secp256k1 elliptic curve utility functions.
+
+use super::traits::{ECPoint, ECScalar};
+use generic_array::typenum::U32;
+use generic_array::GenericArray;
+use getrandom::getrandom;
+use k256::ecdsa::VerifyKey;
+use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use k256::{AffinePoint, EncodedPoint, ProjectivePoint, Scalar};
+#[cfg(feature = "num_bigint")]
+use num_traits::identities::Zero;
+use rust_bigint::traits::Converter;
+use rust_bigint::BigInt;
+use serde::de;
+use serde::de::Visitor;
+use serde::ser::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer};
+use std::ops::{Add, Mul, Sub};
+use std::sync::atomic;
+use std::{fmt, ptr};
+use zeroize::Zeroize;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Secp256k1Scalar {
+    purpose: &'static str,
+    pub(crate) fe: Scalar,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Secp256k1Point {
+    purpose: &'static str,
+    pub(crate) ge: VerifyKey,
+}
+
+impl Zeroize for Secp256k1Scalar {
+    fn zeroize(&mut self) {
+        let zero_arr = [0u8; 32];
+        let zero = unsafe { std::mem::transmute::<[u8; 32], Scalar>(zero_arr) };
+        let zero_scalar = Secp256k1Scalar {
+            purpose: "zero",
+            fe: zero,
+        };
+        unsafe { ptr::write_volatile(self, zero_scalar) };
+        atomic::fence(atomic::Ordering::SeqCst);
+        atomic::compiler_fence(atomic::Ordering::SeqCst);
+    }
+}
+
+impl ECScalar<Scalar> for Secp256k1Scalar {
+    fn new_random() -> Result<Secp256k1Scalar, ()> {
+        let mut rand_arr_tmp = [0u8; 32];
+        match getrandom(&mut rand_arr_tmp) {
+            Ok(_) => (),
+            Err(_) => return Err(()),
+        };
+        let rand_arr: GenericArray<u8, U32> = *GenericArray::from_slice(&rand_arr_tmp);
+        Ok(Secp256k1Scalar {
+            purpose: "random",
+            fe: Scalar::from_bytes_reduced(&rand_arr),
+        })
+    }
+
+    fn from(n: &BigInt) -> Result<Secp256k1Scalar, ()> {
+        if n >= &Secp256k1Scalar::q() || n < &BigInt::zero() {
+            return Err(());
+        }
+        let tmp = BigInt::to_vec(n);
+        let mut vec = vec![0; 32 - tmp.len()];
+        vec.extend(&tmp);
+        let arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec);
+        Ok(Secp256k1Scalar {
+            purpose: "from_big_int",
+            fe: Scalar::from_bytes_reduced(&arr),
+        })
+    }
+
+    fn to_bigint(&self) -> BigInt {
+        BigInt::from_bytes(&self.fe.to_bytes())
+    }
+
+    fn q() -> BigInt {
+        const CURVE_ORDER: [u8; 32] = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
+            0xd0, 0x36, 0x41, 0x41,
+        ];
+        BigInt::from_bytes(&CURVE_ORDER.as_ref())
+    }
+
+    fn add(&self, other: &Scalar) -> Result<Secp256k1Scalar, ()> {
+        let res = self.fe + other;
+        if bool::from(res.is_zero()) {
+            return Err(());
+        }
+        Ok(Secp256k1Scalar {
+            purpose: "add",
+            fe: res,
+        })
+    }
+
+    fn mul(&self, other: &Scalar) -> Result<Secp256k1Scalar, ()> {
+        let res = self.fe * other;
+        if bool::from(res.is_zero()) {
+            return Err(());
+        }
+        Ok(Secp256k1Scalar {
+            purpose: "mul",
+            fe: res,
+        })
+    }
+
+    fn sub(&self, other: &Scalar) -> Result<Secp256k1Scalar, ()> {
+        let res = self.fe - other;
+        if bool::from(res.is_zero()) {
+            return Err(());
+        }
+        Ok(Secp256k1Scalar {
+            purpose: "sub",
+            fe: res,
+        })
+    }
+
+    fn invert(&self) -> Result<Secp256k1Scalar, ()> {
+        let res = self.fe.invert();
+        if bool::from(res.is_none()) {
+            return Err(());
+        }
+        Ok(Secp256k1Scalar {
+            purpose: "invert",
+            fe: res.unwrap(),
+        })
+    }
+
+    /// convert to vector and pad with zeros if necessary
+    fn to_vec(&self) -> Vec<u8> {
+        let vec = BigInt::to_vec(&self.to_bigint());
+        let mut v = vec![0; 32 - vec.len()];
+        v.extend(&vec);
+        v
+    }
+}
+
+impl Mul<Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn mul(self, other: Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).mul(&other.fe)
+    }
+}
+
+impl<'o> Mul<&'o Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn mul(self, other: &'o Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).mul(&other.fe)
+    }
+}
+
+impl Add<Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn add(self, other: Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).add(&other.fe)
+    }
+}
+
+impl<'o> Add<&'o Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn add(self, other: &'o Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).add(&other.fe)
+    }
+}
+
+impl Sub<Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn sub(self, other: Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).sub(&other.fe)
+    }
+}
+
+impl<'o> Sub<&'o Secp256k1Scalar> for Secp256k1Scalar {
+    type Output = Result<Secp256k1Scalar, ()>;
+    fn sub(self, other: &'o Secp256k1Scalar) -> Result<Secp256k1Scalar, ()> {
+        (&self).sub(&other.fe)
+    }
+}
+
+impl Serialize for Secp256k1Scalar {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{:0>64}", self.to_bigint().to_hex()))
+    }
+}
+
+impl<'de> Deserialize<'de> for Secp256k1Scalar {
+    fn deserialize<D>(deserializer: D) -> Result<Secp256k1Scalar, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Secp256k1ScalarVisitor)
+    }
+}
+
+struct Secp256k1ScalarVisitor;
+
+impl<'de> Visitor<'de> for Secp256k1ScalarVisitor {
+    type Value = Secp256k1Scalar;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Secp256k1Scalar")
+    }
+
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Secp256k1Scalar, E> {
+        let v = match BigInt::from_hex(&s) {
+            Ok(v) => v,
+            Err(_) => return Err(de::Error::custom(format!("Invalid hex string: {}", s))),
+        };
+        match ECScalar::from(&v) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(de::Error::custom(format!("Invalid Secp256k1Scalar: {}", s))),
+        }
+    }
+}
+
+impl Zeroize for Secp256k1Point {
+    fn zeroize(&mut self) {
+        unsafe { ptr::write_volatile(self, Secp256k1Point::generator()) };
+        atomic::fence(atomic::Ordering::SeqCst);
+        atomic::compiler_fence(atomic::Ordering::SeqCst);
+    }
+}
+
+impl ECPoint<VerifyKey, Scalar> for Secp256k1Point {
+    fn generator() -> Secp256k1Point {
+        Secp256k1Point {
+            purpose: "base_fe",
+            ge: VerifyKey::from_encoded_point(&AffinePoint::generator().to_encoded_point(false))
+                .unwrap(),
+        }
+    }
+
+    fn to_bigint(&self) -> BigInt {
+        BigInt::from_bytes(&self.ge.to_encoded_point(true).as_bytes())
+    }
+
+    fn x_coor(&self) -> BigInt {
+        BigInt::from_bytes(&EncodedPoint::from(&self.ge).x())
+    }
+
+    fn y_coor(&self) -> BigInt {
+        // unwrap() is safe because self has been validated on creation
+        let tmp = AffinePoint::from_encoded_point(&self.ge.to_encoded_point(false)).unwrap();
+        // unwrap() is safe because EncodedPoint is uncompressed (see previous line)
+        BigInt::from_bytes(&tmp.to_encoded_point(false).y().unwrap())
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Result<Secp256k1Point, ()> {
+        match VerifyKey::new(&bytes) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "random",
+                ge: v,
+            }),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn to_vec(&self) -> Vec<u8> {
+        // unwrap() is safe because self has been validated on creation
+        let tmp = AffinePoint::from_encoded_point(&EncodedPoint::from(&self.ge)).unwrap();
+        tmp.to_encoded_point(false).as_ref().to_vec()
+    }
+
+    fn scalar_mul(&self, fe: &Scalar) -> Result<Secp256k1Point, ()> {
+        let point = AffinePoint::from_encoded_point(&EncodedPoint::from(&self.ge));
+        if bool::from(point.is_none()) {
+            return Err(());
+        }
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point.unwrap()) * fe)
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "mul",
+                ge: v,
+            }),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn add_point(&self, other: &VerifyKey) -> Result<Secp256k1Point, ()> {
+        let point1 = AffinePoint::from_encoded_point(&EncodedPoint::from(&self.ge));
+        let point2 = AffinePoint::from_encoded_point(&EncodedPoint::from(other));
+        if bool::from(point1.is_none()) || bool::from(point2.is_none()) {
+            return Err(());
+        }
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point1.unwrap()) + ProjectivePoint::from(point2.unwrap()))
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "combine",
+                ge: v,
+            }),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn sub_point(&self, other: &VerifyKey) -> Result<Secp256k1Point, ()> {
+        let point1 = AffinePoint::from_encoded_point(&EncodedPoint::from(&self.ge));
+        let point2 = AffinePoint::from_encoded_point(&EncodedPoint::from(other));
+        if bool::from(point1.is_none()) || bool::from(point2.is_none()) {
+            return Err(());
+        }
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point1.unwrap()) - ProjectivePoint::from(point2.unwrap()))
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "sub",
+                ge: v,
+            }),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn from_coor(x: &BigInt, y: &BigInt) -> Result<Secp256k1Point, ()> {
+        const COOR_SIZE: usize = 32;
+        let vec_x_tmp = BigInt::to_vec(x);
+        // pad with zeros if necessary
+        let mut vec_x = vec![0; COOR_SIZE - vec_x_tmp.len()];
+        vec_x.extend(vec_x_tmp);
+        let vec_y_tmp = BigInt::to_vec(y);
+        // pad with zeros if necessary
+        let mut vec_y = vec![0; COOR_SIZE - vec_y_tmp.len()];
+        vec_y.extend(vec_y_tmp);
+
+        let x_arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec_x);
+        let y_arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec_y);
+        match VerifyKey::from_encoded_point(&EncodedPoint::from_affine_coordinates(
+            &x_arr, &y_arr, false,
+        )) {
+            Ok(v) => Ok(Secp256k1Point {
+                purpose: "base_fe",
+                ge: v,
+            }),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn to_hex(&self) -> String {
+        format!("{:0>66}", self.to_bigint().to_hex())
+    }
+
+    fn from_hex(s: &str) -> Result<Secp256k1Point, ()> {
+        let v = match BigInt::from_hex(s) {
+            Ok(v) => v,
+            Err(_) => return Err(()),
+        };
+        let point = match Secp256k1Point::from_bigint(&v) {
+            Ok(v) => v,
+            Err(_) => return Err(()),
+        };
+        Ok(point)
+    }
+}
+
+impl Secp256k1Point {
+    // derive point from BigInt
+    pub fn from_bigint(i: &BigInt) -> Result<Secp256k1Point, ()> {
+        match Secp256k1Point::from_bytes(&BigInt::to_vec(i)) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(()),
+        }
+    }
+}
+
+impl Mul<Secp256k1Scalar> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn mul(self, other: Secp256k1Scalar) -> Result<Secp256k1Point, ()> {
+        self.scalar_mul(&other.fe)
+    }
+}
+
+impl<'o> Mul<&'o Secp256k1Scalar> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn mul(self, other: &'o Secp256k1Scalar) -> Result<Secp256k1Point, ()> {
+        self.scalar_mul(&other.fe)
+    }
+}
+
+impl<'o> Mul<&'o Secp256k1Scalar> for &'o Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn mul(self, other: &'o Secp256k1Scalar) -> Result<Secp256k1Point, ()> {
+        self.scalar_mul(&other.fe)
+    }
+}
+
+impl Add<Secp256k1Point> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn add(self, other: Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.add_point(&other.ge)
+    }
+}
+
+impl<'o> Add<&'o Secp256k1Point> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn add(self, other: &'o Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.add_point(&other.ge)
+    }
+}
+
+impl<'o> Add<&'o Secp256k1Point> for &'o Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn add(self, other: &'o Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.add_point(&other.ge)
+    }
+}
+
+impl Sub<Secp256k1Point> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn sub(self, other: Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.sub_point(&other.ge)
+    }
+}
+
+impl<'o> Sub<&'o Secp256k1Point> for Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn sub(self, other: &'o Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.sub_point(&other.ge)
+    }
+}
+
+impl<'o> Sub<&'o Secp256k1Point> for &'o Secp256k1Point {
+    type Output = Result<Secp256k1Point, ()>;
+    fn sub(self, other: &'o Secp256k1Point) -> Result<Secp256k1Point, ()> {
+        self.sub_point(&other.ge)
+    }
+}
+
+impl Serialize for Secp256k1Point {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Secp256k1Point {
+    fn deserialize<D>(deserializer: D) -> Result<Secp256k1Point, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Secp256k1PointVisitor)
+    }
+}
+
+struct Secp256k1PointVisitor;
+
+impl<'de> Visitor<'de> for Secp256k1PointVisitor {
+    type Value = Secp256k1Point;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Secp256k1Point")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Secp256k1Point, E>
+    where
+        E: de::Error,
+    {
+        match Secp256k1Point::from_hex(&s.to_string()) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(E::custom(format!(
+                "Error deriving Secp256k1Point from string: {}",
+                s
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BigInt, Secp256k1Point, Secp256k1Scalar};
+    use crate::curves::traits::{ECPoint, ECScalar};
+    use rust_bigint::traits::{Converter, Modulo, Samplable};
+
+    fn base_point2() -> Secp256k1Point {
+        let random_scalar: Secp256k1Scalar = Secp256k1Scalar::new_random().unwrap();
+        let base_point = Secp256k1Point::generator();
+        let pk = base_point.scalar_mul(&random_scalar.fe).unwrap();
+        Secp256k1Point {
+            purpose: "base_fe",
+            ge: pk.ge,
+        }
+    }
+
+    fn random_point() -> Secp256k1Point {
+        let random_scalar: Secp256k1Scalar = Secp256k1Scalar::new_random().unwrap();
+        let pk = Secp256k1Point::generator()
+            .scalar_mul(&random_scalar.fe)
+            .unwrap();
+        Secp256k1Point {
+            purpose: "random_point",
+            ge: pk.ge,
+        }
+    }
+
+    #[test]
+    fn serialize_sk() {
+        let scalar: Secp256k1Scalar = ECScalar::from(&BigInt::from(123456)).unwrap();
+        let s = serde_json::to_string(&scalar).expect("Failed in serialization");
+        assert_eq!(
+            s,
+            "\"000000000000000000000000000000000000000000000000000000000001e240\""
+        );
+    }
+
+    #[test]
+    fn serialize_rand_pk_verify_pad() {
+        let vx = BigInt::from_hex(
+            &"ccaf75ab7960a01eb421c0e2705f6e84585bd0a094eb6af928c892a4a2912508".to_string(),
+        )
+        .unwrap();
+
+        let vy = BigInt::from_hex(
+            &"e788e294bd64eee6a73d2fc966897a31eb370b7e8e9393b0d8f4f820b48048df".to_string(),
+        )
+        .unwrap();
+
+        Secp256k1Point::from_coor(&vx, &vy).unwrap(); // x and y of size 32
+
+        let x = BigInt::from_hex(
+            &"5f6853305467a385b56a5d87f382abb52d10835a365ec265ce510e04b3c3366f".to_string(),
+        )
+        .unwrap();
+
+        let y = BigInt::from_hex(
+            &"b868891567ca1ee8c44706c0dc190dd7779fe6f9b92ced909ad870800451e3".to_string(),
+        )
+        .unwrap();
+
+        Secp256k1Point::from_coor(&x, &y).unwrap(); // x and y not of size 32 each
+
+        let r = random_point();
+        let r_expected = Secp256k1Point::from_coor(&r.x_coor(), &r.y_coor()).unwrap();
+
+        assert_eq!(r.x_coor(), r_expected.x_coor());
+        assert_eq!(r.y_coor(), r_expected.y_coor());
+    }
+
+    #[test]
+    fn deserialize_sk() {
+        let s = "\"1e240\"";
+        let dummy: Secp256k1Scalar = serde_json::from_str(s).expect("Failed in serialization");
+
+        let sk: Secp256k1Scalar = ECScalar::from(&BigInt::from(123456)).unwrap();
+
+        assert_eq!(dummy, sk);
+    }
+
+    #[test]
+    fn serialize_pk() {
+        let pk = Secp256k1Point::generator();
+        let s = serde_json::to_string(&pk).expect("Failed in serialization");
+        let expected = pk.to_bigint().to_hex();
+        assert_eq!(
+            s,
+            serde_json::to_string(&("0".to_string() + &expected)).unwrap()
+        );
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in serialization");
+        assert_eq!(des_pk.ge, pk.ge);
+    }
+
+    #[test]
+    fn bincode_pk() {
+        let pk = Secp256k1Point::generator();
+        let bin = bincode::serialize(&pk).unwrap();
+        let decoded: Secp256k1Point = bincode::deserialize(bin.as_slice()).unwrap();
+        assert_eq!(decoded.ge, pk.ge);
+    }
+
+    #[test]
+    fn test_serdes_pk() {
+        let pk = Secp256k1Point::generator();
+        let s = serde_json::to_string(&pk).expect("Failed in serialization");
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in deserialization");
+        assert_eq!(des_pk.ge, pk.ge);
+
+        let pk = base_point2();
+        let s = serde_json::to_string(&pk).expect("Failed in serialization");
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in deserialization");
+        assert_eq!(des_pk.ge, pk.ge);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_serdes_bad_pk() {
+        let pk = Secp256k1Point::generator();
+        let mut s = serde_json::to_string(&pk).expect("Failed in serialization");
+        // we make sure that the string encodes invalid point:
+        s = s.replace("2770", "2780");
+        let des_pk: Secp256k1Point = serde_json::from_str(&s).expect("Failed in deserialization");
+        assert_eq!(des_pk, pk);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_from_bytes() {
+        let vec = BigInt::to_vec(&BigInt::from(1337));
+        Secp256k1Point::from_bytes(&vec).unwrap();
+    }
+
+    #[test]
+    fn test_from_bytes_3() {
+        let test_vec = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 1, 2, 3, 4, 5, 6,
+        ];
+        let result = Secp256k1Point::from_bytes(&test_vec);
+        assert!(result.is_ok() | result.is_err())
+    }
+
+    #[test]
+    fn test_from_bytes_4() {
+        let test_vec = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6,
+        ];
+        let result = Secp256k1Point::from_bytes(&test_vec);
+        assert!(result.is_ok() | result.is_err())
+    }
+
+    #[test]
+    fn test_from_bytes_5() {
+        let test_vec = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5,
+            6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4,
+            5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3,
+            4, 5, 6,
+        ];
+        let result = Secp256k1Point::from_bytes(&test_vec);
+        assert!(result.is_ok() | result.is_err())
+    }
+
+    #[test]
+    fn test_add_sub() {
+        let q = Secp256k1Scalar::q();
+        let start: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let b: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let tmp = BigInt::mod_add(&start.to_bigint(), &b.to_bigint(), &q);
+        let end = BigInt::mod_sub(&tmp, &b.to_bigint(), &q);
+        assert_eq!(start.to_bigint(), end);
+    }
+
+    #[test]
+    fn test_minus_point() {
+        let a: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let b: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let b_bn = b.to_bigint();
+        let q = Secp256k1Scalar::q();
+        let minus_b = BigInt::mod_sub(&q, &b_bn, &q);
+        let a_minus_b = BigInt::mod_add(&a.to_bigint(), &minus_b, &q);
+        let a_minus_b_fe: Secp256k1Scalar = ECScalar::from(&a_minus_b).unwrap();
+        let base: Secp256k1Point = ECPoint::generator();
+        let point_ab1 = (base.clone() * a_minus_b_fe).unwrap();
+        let point_a = (base.clone() * a).unwrap();
+        let point_b = (base.clone() * b).unwrap();
+        let point_ab2 = point_a.sub_point(&point_b.ge).unwrap();
+        assert_eq!(point_ab1.ge, point_ab2.ge);
+    }
+
+    #[test]
+    fn test_simple_inversion2() {
+        let a: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
+        let a_inv = a.invert().unwrap();
+        let a_inv_int = a_inv.to_bigint();
+        assert_eq!(
+            a_inv_int,
+            BigInt::from_hex("7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_simple_inversion3() {
+        let a: Secp256k1Scalar = ECScalar::from(&BigInt::from(1234567890)).unwrap();
+        let a_inv = a.invert().unwrap().to_bigint();
+        assert_eq!(
+            a_inv,
+            BigInt::from_hex("6bd555ecd0e4e06df23bfbb091158daaa0c6ba7347f32b95f4484e8dceb39d91")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_invert() {
+        let a_bn = BigInt::sample(256);
+        let a: Secp256k1Scalar = ECScalar::from(&a_bn).unwrap();
+        let a_inv = a.invert().unwrap();
+        let a_inv_bn_1 = BigInt::mod_inv(&a_bn, &Secp256k1Scalar::q());
+        let a_inv_bn_2 = a_inv.to_bigint();
+        assert_eq!(a_inv_bn_1, a_inv_bn_2);
+    }
+
+    #[test]
+    fn test_scalar_mul_scalar() {
+        let a: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let b: Secp256k1Scalar = ECScalar::new_random().unwrap();
+        let c1 = a.mul(&b.fe).unwrap();
+        let c2 = (a * b).unwrap();
+        assert_eq!(c1.fe, c2.fe);
+    }
+
+    #[test]
+    fn test_scalar_mul1() {
+        let base_point = Secp256k1Point::generator();
+        let int: Secp256k1Scalar = ECScalar::from(&BigInt::from(1)).unwrap();
+        let test = (base_point * int).unwrap();
+        assert_eq!(
+            test.x_coor().to_hex(),
+            "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        );
+        assert_eq!(
+            test.y_coor().to_hex(),
+            "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+        );
+    }
+
+    #[test]
+    fn test_scalar_mul2() {
+        let base_point = Secp256k1Point::generator();
+        let int: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
+        let test = (base_point * int).unwrap();
+        assert_eq!(
+            test.x_coor().to_hex(),
+            "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+        );
+        assert_eq!(
+            format!("{:0>64}", test.y_coor().to_hex()),
+            "1ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a"
+        );
+    }
+
+    #[test]
+    fn test_scalar_mul3() {
+        let base_point = Secp256k1Point::generator();
+        let int: Secp256k1Scalar = ECScalar::from(
+            &BigInt::from_hex("7CF27B188D034F7E8A52380304B51AC3C08969E277F21B35A60B48FC47669978")
+                .unwrap(),
+        )
+        .unwrap();
+        let test = (base_point * int).unwrap();
+        assert_eq!(
+            test.x_coor().to_hex(),
+            "6ffaae254d4d5cbb122b076c3af5894111b2389181c86bb7dee5d1f10bb769df"
+        );
+        assert_eq!(
+            format!("{:0>64}", test.y_coor().to_hex()),
+            "56677bfd4c11625f670ac516c7781c296e71d73e79401967cdd071d1fc2c63f2"
+        );
+    }
+
+    #[test]
+    fn test_pk_to_key_slice() {
+        for _ in 1..200 {
+            let r = Secp256k1Scalar::new_random().unwrap();
+            let rg = (Secp256k1Point::generator() * &r).unwrap();
+            let key_slice = rg.to_vec();
+            assert!(key_slice.len() == 65);
+            assert!(key_slice[0].clone() == 4);
+            let rg_prime: Secp256k1Point = ECPoint::from_bytes(&key_slice).unwrap();
+            assert_eq!(rg_prime.ge, rg.ge);
+        }
+    }
+
+    #[test]
+    fn scalar_bigint_conversion1() {
+        let int = BigInt::sample(256);
+        let scalar: Secp256k1Scalar = ECScalar::from(&int).unwrap();
+        assert_eq!(scalar.to_bigint(), int);
+    }
+
+    #[test]
+    fn point_bigint_conversion1() {
+        let g = Secp256k1Point::generator();
+        let h = g.to_bigint();
+        let i = Secp256k1Point::from_bigint(&h).unwrap();
+        assert_eq!(i.ge, g.ge);
+    }
+
+    #[test]
+    fn point_bigint_conversion2() {
+        let g = Secp256k1Point::generator();
+        let r: Secp256k1Scalar = ECScalar::from(&BigInt::sample(256)).unwrap();
+        let point = (g * r).unwrap();
+        let point_int = point.to_bigint();
+        let point_test = Secp256k1Point::from_bigint(&point_int).unwrap();
+        assert_eq!(point.ge, point_test.ge);
+    }
+
+    #[test]
+    fn scalar_bigint_conversion2() {
+        let i = Secp256k1Scalar::new_random().unwrap();
+        let int = i.to_bigint();
+        let j: Secp256k1Scalar = ECScalar::from(&int).unwrap();
+        assert_eq!(i.fe, j.fe);
+    }
+
+    #[test]
+    fn pk_to_hex() {
+        let secret =
+            BigInt::from_hex("79196b247effbe3192763a5c37b18f5d89e7d0a8c83d246917add0a842d5af8b")
+                .unwrap();
+        let sk: Secp256k1Scalar = ECScalar::from(&secret).unwrap();
+        let g = Secp256k1Point::generator();
+        let h = (g * sk).unwrap();
+        assert_eq!(
+            h.to_hex(),
+            "02dc160dee8b88f45df7b83908a0cb07eaaf12c2c31e4e09664351fd008b0a6f6e"
+        );
+    }
+
+    #[test]
+    fn scalar_from_bigint() {
+        let r = Secp256k1Scalar::new_random().unwrap();
+        let int = r.to_bigint();
+        let s: Secp256k1Scalar = ECScalar::from(&int).unwrap();
+        assert_eq!(r.fe, s.fe);
+    }
+
+    #[test]
+    fn add_sub_point() {
+        let g = Secp256k1Point::generator();
+        let i: Secp256k1Scalar = ECScalar::from(&BigInt::from(3)).unwrap();
+        assert_eq!(((g + g).unwrap() + g).unwrap().ge, (g * i).unwrap().ge);
+        assert_eq!(
+            (g + g).unwrap().ge,
+            (((g + g).unwrap() - g).unwrap() + g).unwrap().ge
+        );
+    }
+
+    #[test]
+    fn add_scalar() {
+        let i: Secp256k1Scalar = ECScalar::from(&BigInt::from(1)).unwrap();
+        let j: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
+        assert_eq!((i.clone() + i.clone()).unwrap().fe, j.fe);
+        assert_eq!(
+            (((i.clone() + i.clone()).unwrap() + i.clone()).unwrap() + i.clone())
+                .unwrap()
+                .fe,
+            (j.clone() + j.clone()).unwrap().fe
+        );
+    }
+
+    #[test]
+    fn sub_scalar() {
+        let i: Secp256k1Scalar = ECScalar::from(&BigInt::from(1)).unwrap();
+        assert_eq!(
+            ((i.clone() + i.clone()).unwrap() - i.clone()).unwrap().fe,
+            i.fe
+        );
+        let j: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
+        assert_eq!(
+            ((j.clone() + j.clone()).unwrap() - j.clone()).unwrap().fe,
+            j.fe
+        );
+        let k = Secp256k1Scalar::new_random().unwrap();
+        assert_eq!(
+            ((k.clone() + k.clone()).unwrap() - k.clone()).unwrap().fe,
+            k.fe
+        );
+    }
+
+    #[test]
+    fn mul_scalar() {
+        let i: Secp256k1Scalar = ECScalar::from(&BigInt::from(1)).unwrap();
+        let j: Secp256k1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
+        assert_eq!((j.clone() * i.clone()).unwrap().fe, j.fe);
+    }
+}

--- a/mpc-wallet/mpc-wallet-lib/src/curves/secp256_r1.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/secp256_r1.rs
@@ -65,7 +65,7 @@ impl ECScalar<Scalar> for Secp256r1Scalar {
             return Err(());
         }
         let tmp = BigInt::to_vec(n);
-        let mut vec = vec!(0; 32 - tmp.len());
+        let mut vec = vec![0; 32 - tmp.len()];
         vec.extend(&tmp);
         let arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec);
         Ok(Secp256r1Scalar {
@@ -233,7 +233,8 @@ impl ECPoint<VerifyKey, Scalar> for Secp256r1Point {
     fn generator() -> Secp256r1Point {
         Secp256r1Point {
             purpose: "base_fe",
-            ge: VerifyKey::from_encoded_point(&AffinePoint::generator().to_encoded_point(false)).unwrap(),
+            ge: VerifyKey::from_encoded_point(&AffinePoint::generator().to_encoded_point(false))
+                .unwrap(),
         }
     }
 
@@ -273,7 +274,11 @@ impl ECPoint<VerifyKey, Scalar> for Secp256r1Point {
         if bool::from(point.is_none()) {
             return Err(());
         }
-        match VerifyKey::from_encoded_point(&(ProjectivePoint::from(point.unwrap()) * fe).to_affine().to_encoded_point(true)) {
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point.unwrap()) * fe)
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
             Ok(v) => Ok(Secp256r1Point {
                 purpose: "mul",
                 ge: v,
@@ -288,7 +293,11 @@ impl ECPoint<VerifyKey, Scalar> for Secp256r1Point {
         if bool::from(point1.is_none()) || bool::from(point2.is_none()) {
             return Err(());
         }
-        match VerifyKey::from_encoded_point(&(ProjectivePoint::from(point1.unwrap()) + ProjectivePoint::from(point2.unwrap())).to_affine().to_encoded_point(true)) {
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point1.unwrap()) + ProjectivePoint::from(point2.unwrap()))
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
             Ok(v) => Ok(Secp256r1Point {
                 purpose: "combine",
                 ge: v,
@@ -303,7 +312,11 @@ impl ECPoint<VerifyKey, Scalar> for Secp256r1Point {
         if bool::from(point1.is_none()) || bool::from(point2.is_none()) {
             return Err(());
         }
-        match VerifyKey::from_encoded_point(&(ProjectivePoint::from(point1.unwrap()) - ProjectivePoint::from(point2.unwrap())).to_affine().to_encoded_point(true)) {
+        match VerifyKey::from_encoded_point(
+            &(ProjectivePoint::from(point1.unwrap()) - ProjectivePoint::from(point2.unwrap()))
+                .to_affine()
+                .to_encoded_point(true),
+        ) {
             Ok(v) => Ok(Secp256r1Point {
                 purpose: "sub",
                 ge: v,
@@ -325,7 +338,9 @@ impl ECPoint<VerifyKey, Scalar> for Secp256r1Point {
 
         let x_arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec_x);
         let y_arr: GenericArray<u8, U32> = *GenericArray::from_slice(&vec_y);
-        match VerifyKey::from_encoded_point(&EncodedPoint::from_affine_coordinates(&x_arr, &y_arr, false)) {
+        match VerifyKey::from_encoded_point(&EncodedPoint::from_affine_coordinates(
+            &x_arr, &y_arr, false,
+        )) {
             Ok(v) => Ok(Secp256r1Point {
                 purpose: "base_fe",
                 ge: v,
@@ -483,7 +498,9 @@ mod tests {
 
     fn random_point() -> Secp256r1Point {
         let random_scalar: Secp256r1Scalar = Secp256r1Scalar::new_random().unwrap();
-        let pk = Secp256r1Point::generator().scalar_mul(&random_scalar.fe).unwrap();
+        let pk = Secp256r1Point::generator()
+            .scalar_mul(&random_scalar.fe)
+            .unwrap();
         Secp256r1Point {
             purpose: "random_point",
             ge: pk.ge,
@@ -731,7 +748,8 @@ mod tests {
         let int: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("7CF27B188D034F7E8A52380304B51AC3C08969E277F21B35A60B48FC47669978")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let test = (base_point * int).unwrap();
         assert_eq!(
             test.x_coor().to_hex(),
@@ -816,7 +834,10 @@ mod tests {
         let g = Secp256r1Point::generator();
         let i: Secp256r1Scalar = ECScalar::from(&BigInt::from(3)).unwrap();
         assert_eq!(((g + g).unwrap() + g).unwrap().ge, (g * i).unwrap().ge);
-        assert_eq!((g + g).unwrap().ge, (((g + g).unwrap() - g).unwrap() + g).unwrap().ge);
+        assert_eq!(
+            (g + g).unwrap().ge,
+            (((g + g).unwrap() - g).unwrap() + g).unwrap().ge
+        );
     }
 
     #[test]
@@ -825,7 +846,9 @@ mod tests {
         let j: Secp256r1Scalar = ECScalar::from(&BigInt::from(2)).unwrap();
         assert_eq!((i.clone() + i.clone()).unwrap().fe, j.fe);
         assert_eq!(
-            (((i.clone() + i.clone()).unwrap() + i.clone()).unwrap() + i.clone()).unwrap().fe,
+            (((i.clone() + i.clone()).unwrap() + i.clone()).unwrap() + i.clone())
+                .unwrap()
+                .fe,
             (j.clone() + j.clone()).unwrap().fe
         );
     }

--- a/mpc-wallet/mpc-wallet-lib/src/curves/traits.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/traits.rs
@@ -1,20 +1,17 @@
 // based on MIT/Apache-licensed https://github.com/KZen-networks/curv/blob/master/src/elliptic/curves/traits.rs
 
-use crate::ErrorKey;
 use rust_bigint::BigInt;
 
 pub trait ECScalar<SK> {
     fn new_random() -> Self;
-    fn zero() -> Self;
-    fn get_element(&self) -> SK;
-    fn set_element(&mut self, element: SK);
     fn from(n: &BigInt) -> Self;
-    fn to_big_int(&self) -> BigInt;
+    fn to_bigint(&self) -> BigInt;
     fn q() -> BigInt;
     fn add(&self, other: &SK) -> Self;
     fn mul(&self, other: &SK) -> Self;
     fn sub(&self, other: &SK) -> Self;
     fn invert(&self) -> Self;
+    fn to_vec(&self) -> Vec<u8>;
 }
 
 pub trait ECPoint<PK, SK>
@@ -22,12 +19,11 @@ where
     Self: Sized,
 {
     fn generator() -> Self;
-    fn get_element(&self) -> PK;
-    fn x_coor(&self) -> Option<BigInt>;
-    fn y_coor(&self) -> Option<BigInt>;
-    fn bytes_compressed_to_big_int(&self) -> BigInt;
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ErrorKey>;
-    fn pk_to_key_slice(&self) -> Vec<u8>;
+    fn x_coor(&self) -> BigInt;
+    fn y_coor(&self) -> BigInt;
+    fn to_bigint(&self) -> BigInt;
+    fn from_bytes(bytes: &[u8]) -> Result<Self, ()>;
+    fn to_vec(&self) -> Vec<u8>;
     fn scalar_mul(&self, fe: &SK) -> Self;
     fn add_point(&self, other: &PK) -> Self;
     fn sub_point(&self, other: &PK) -> Self;

--- a/mpc-wallet/mpc-wallet-lib/src/curves/traits.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/curves/traits.rs
@@ -2,15 +2,18 @@
 
 use rust_bigint::BigInt;
 
-pub trait ECScalar<SK> {
-    fn new_random() -> Self;
-    fn from(n: &BigInt) -> Self;
+pub trait ECScalar<SK>
+where
+    Self: Sized,
+{
+    fn new_random() -> Result<Self, ()>;
+    fn from(n: &BigInt) -> Result<Self, ()>;
     fn to_bigint(&self) -> BigInt;
     fn q() -> BigInt;
-    fn add(&self, other: &SK) -> Self;
-    fn mul(&self, other: &SK) -> Self;
-    fn sub(&self, other: &SK) -> Self;
-    fn invert(&self) -> Self;
+    fn add(&self, other: &SK) -> Result<Self, ()>;
+    fn mul(&self, other: &SK) -> Result<Self, ()>;
+    fn sub(&self, other: &SK) -> Result<Self, ()>;
+    fn invert(&self) -> Result<Self, ()>;
     fn to_vec(&self) -> Vec<u8>;
 }
 
@@ -24,10 +27,10 @@ where
     fn to_bigint(&self) -> BigInt;
     fn from_bytes(bytes: &[u8]) -> Result<Self, ()>;
     fn to_vec(&self) -> Vec<u8>;
-    fn scalar_mul(&self, fe: &SK) -> Self;
-    fn add_point(&self, other: &PK) -> Self;
-    fn sub_point(&self, other: &PK) -> Self;
-    fn from_coor(x: &BigInt, y: &BigInt) -> Self;
+    fn scalar_mul(&self, fe: &SK) -> Result<Self, ()>;
+    fn add_point(&self, other: &PK) -> Result<Self, ()>;
+    fn sub_point(&self, other: &PK) -> Result<Self, ()>;
+    fn from_coor(x: &BigInt, y: &BigInt) -> Result<Self, ()>;
     fn to_hex(&self) -> String;
     fn from_hex(s: &str) -> Result<Self, ()>;
 }

--- a/mpc-wallet/mpc-wallet-lib/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/lib.rs
@@ -7,8 +7,3 @@ pub mod curves;
 pub mod server;
 pub use rust_bigint;
 pub use paillier_common;
-
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
-pub enum ErrorKey {
-    InvalidPublicKey,
-}

--- a/mpc-wallet/mpc-wallet-lib/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/lib.rs
@@ -5,5 +5,5 @@ pub mod client;
 pub mod common;
 pub mod curves;
 pub mod server;
-pub use rust_bigint;
 pub use paillier_common;
+pub use rust_bigint;

--- a/mpc-wallet/mpc-wallet-lib/src/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/server.rs
@@ -45,15 +45,18 @@ pub fn compute_rpool_secp256r1(
     }
     // execute scalar multiplication in parallel
     tmp.par_iter_mut().for_each(|i| {
-        *i = format!(
-            // use strings with leading zeros for ME
-            "{:0>66}",
-            client_dh_publics[i.parse::<usize>().unwrap()]
-                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
-                .to_bigint()
-                .to_hex()
-        )
+        *i = match client_dh_publics[i.parse::<usize>().unwrap()].scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe) {
+            // use string with leading zeros for ME
+            Ok(v) => format!("{:0>66}",v.to_bigint().to_hex()),
+            Err(_) => "".to_string(),
+        };
     });
+    // check if any scalar multiplication failed during parallel execution
+    for item in tmp.iter().take(server_dh_secrets.len()) {        
+        if item.is_empty() {
+            return Err(());
+        }
+    }
     for i in 0..server_dh_secrets.len() {
         rpool_new.insert(tmp[i].clone(), server_dh_secrets[i].clone());
     }
@@ -75,18 +78,20 @@ pub fn compute_rpool_secp256k1(
     }
     // execute scalar multiplication in parallel
     tmp.par_iter_mut().for_each(|i| {
-        *i = format!(
-            // use strings with leading zeros for ME
-            "{:0>66}",
-            client_dh_publics[i.parse::<usize>().unwrap()]
-                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
-                .to_bigint()
-                .to_hex()
-        )
+        *i = match client_dh_publics[i.parse::<usize>().unwrap()].scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe) {
+            // use string with leading zeros for ME
+            Ok(v) => format!("{:0>66}", v.to_bigint().to_hex()),
+            Err(_) => "".to_string(),
+        };
     });
+    // check if any scalar multiplication failed during parallel execution
+    for item in tmp.iter().take(server_dh_secrets.len()) {        
+        if item.is_empty() {
+            return Err(());
+        }
+    }
     for i in 0..server_dh_secrets.len() {
-        let to_insert = server_dh_secrets[i].clone();
-        rpool_new.insert(tmp[i].clone(), to_insert);
+        rpool_new.insert(tmp[i].clone(), server_dh_secrets[i].clone());
     }
     Ok(rpool_new)
 }
@@ -224,7 +229,7 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("ffa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -246,7 +251,7 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("efa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -268,7 +273,7 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("ffa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("3ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -290,7 +295,7 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("953fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("2dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),
@@ -312,7 +317,7 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("a53fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("2dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),
@@ -334,7 +339,7 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("953fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        );
+        ).unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("3dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),

--- a/mpc-wallet/mpc-wallet-lib/src/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/server.rs
@@ -2,18 +2,18 @@
  * Server functions for MPC-based API keys
  */
 
-use crate::common::{correct_key_proof_rho, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE, verify};
+use crate::common::{correct_key_proof_rho, verify, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
-use rust_bigint::traits::{BitManipulation, Converter, Modulo, ZeroizeBN};
-use rust_bigint::BigInt;
 #[cfg(feature = "num_bigint")]
 use num_integer::Integer;
 use paillier_common::{
     extract_nroot, Decrypt, DecryptionKey, EncryptionKey, KeyGeneration, Paillier, RawCiphertext,
 };
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
+use rust_bigint::traits::{BitManipulation, Converter, Modulo, ZeroizeBN};
+use rust_bigint::BigInt;
 use std::cmp;
 use std::collections::HashMap;
 
@@ -45,14 +45,16 @@ pub fn compute_rpool_secp256r1(
     }
     // execute scalar multiplication in parallel
     tmp.par_iter_mut().for_each(|i| {
-        *i = match client_dh_publics[i.parse::<usize>().unwrap()].scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe) {
+        *i = match client_dh_publics[i.parse::<usize>().unwrap()]
+            .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
+        {
             // use string with leading zeros for ME
-            Ok(v) => format!("{:0>66}",v.to_bigint().to_hex()),
+            Ok(v) => format!("{:0>66}", v.to_bigint().to_hex()),
             Err(_) => "".to_string(),
         };
     });
     // check if any scalar multiplication failed during parallel execution
-    for item in tmp.iter().take(server_dh_secrets.len()) {        
+    for item in tmp.iter().take(server_dh_secrets.len()) {
         if item.is_empty() {
             return Err(());
         }
@@ -78,14 +80,16 @@ pub fn compute_rpool_secp256k1(
     }
     // execute scalar multiplication in parallel
     tmp.par_iter_mut().for_each(|i| {
-        *i = match client_dh_publics[i.parse::<usize>().unwrap()].scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe) {
+        *i = match client_dh_publics[i.parse::<usize>().unwrap()]
+            .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
+        {
             // use string with leading zeros for ME
             Ok(v) => format!("{:0>66}", v.to_bigint().to_hex()),
             Err(_) => "".to_string(),
         };
     });
     // check if any scalar multiplication failed during parallel execution
-    for item in tmp.iter().take(server_dh_secrets.len()) {        
+    for item in tmp.iter().take(server_dh_secrets.len()) {
         if item.is_empty() {
             return Err(());
         }
@@ -175,7 +179,7 @@ fn correct_key_proof_sigma(paillier_sk: &DecryptionKey, rho: &[BigInt]) -> Vec<B
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{CorrectKeyProof, Curve, PAILLIER_KEY_SIZE, publickey_from_secretkey};
+    use crate::common::{publickey_from_secretkey, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
     use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
     use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
     use crate::curves::traits::ECScalar;
@@ -183,9 +187,9 @@ mod tests {
         complete_sig, compute_rpool_secp256k1, compute_rpool_secp256r1, correct_key_proof_sigma,
         generate_paillier_keypair, generate_paillier_proof,
     };
+    use paillier_common::{DecryptionKey, MinimalDecryptionKey};
     use rust_bigint::traits::{Converter, NumberTests};
     use rust_bigint::BigInt;
-    use paillier_common::{DecryptionKey, MinimalDecryptionKey};
     use std::collections::HashMap;
 
     #[test]
@@ -229,7 +233,8 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("ffa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -251,7 +256,8 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("efa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("2ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -273,7 +279,8 @@ mod tests {
         let dh_secret: Secp256r1Scalar = ECScalar::from(
             &BigInt::from_hex("ffa8b1420c958881923ba9f7fcaf1c5bd994499d31da5d677ca9fa79c5762a28")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256r1Point::from_bigint(
             &BigInt::from_hex("3ba1b94b7ab036e2597081e3127d762e02f9967cc7badedfe1cc7ee142a75aba0")
                 .unwrap(),
@@ -295,7 +302,8 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("953fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("2dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),
@@ -317,7 +325,8 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("a53fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("2dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),
@@ -339,7 +348,8 @@ mod tests {
         let dh_secret: Secp256k1Scalar = ECScalar::from(
             &BigInt::from_hex("953fe5d3d0f74c98dc78fec8482f4d5245727e21109177851a338e92a0b717c2")
                 .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let dh_public = Secp256k1Point::from_bigint(
             &BigInt::from_hex("3dc0573e3f91dc0915f50f053c1f361772a916b927dc782068dedb44c02d54eee")
                 .unwrap(),
@@ -367,11 +377,17 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
+        let (r_, s, recid) =
+            complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
         assert_eq!(
             r_,
             BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
@@ -397,7 +413,12 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -416,7 +437,12 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -435,7 +461,12 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -454,7 +485,12 @@ mod tests {
             BigInt::from_hex("a8779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -473,7 +509,12 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -491,11 +532,17 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
+        let (r_, s, recid) =
+            complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
         assert_eq!(
             r_,
             BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
@@ -521,7 +568,12 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -540,7 +592,12 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -559,7 +616,12 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -578,7 +640,12 @@ mod tests {
             BigInt::from_hex("f1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();
@@ -597,7 +664,12 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let pk = publickey_from_secretkey(
+            &BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1")
+                .unwrap(),
+            curve,
+        )
+        .unwrap();
         let msg_hash =
             BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
                 .unwrap();

--- a/mpc-wallet/mpc-wallet-lib/src/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/server.rs
@@ -49,8 +49,8 @@ pub fn compute_rpool_secp256r1(
             // use strings with leading zeros for ME
             "{:0>66}",
             client_dh_publics[i.parse::<usize>().unwrap()]
-                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].get_element())
-                .bytes_compressed_to_big_int()
+                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
+                .to_bigint()
                 .to_hex()
         )
     });
@@ -79,8 +79,8 @@ pub fn compute_rpool_secp256k1(
             // use strings with leading zeros for ME
             "{:0>66}",
             client_dh_publics[i.parse::<usize>().unwrap()]
-                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].get_element())
-                .bytes_compressed_to_big_int()
+                .scalar_mul(&server_dh_secrets[i.parse::<usize>().unwrap()].fe)
+                .to_bigint()
                 .to_hex()
         )
     });
@@ -110,16 +110,16 @@ pub fn complete_sig(
             Err(_) => return Err(()),
         };
         q = Secp256k1Scalar::q();
-        rx = r_point.x_coor().unwrap().mod_floor(&q);
-        ry = r_point.y_coor().unwrap().mod_floor(&q);
+        rx = r_point.x_coor().mod_floor(&q);
+        ry = r_point.y_coor().mod_floor(&q);
     } else if curve == Curve::Secp256r1 {
         let r_point = match Secp256r1Point::from_bigint(&r) {
             Ok(v) => v,
             Err(_) => return Err(()),
         };
         q = Secp256r1Scalar::q();
-        rx = r_point.x_coor().unwrap().mod_floor(&q);
-        ry = r_point.y_coor().unwrap().mod_floor(&q);
+        rx = r_point.x_coor().mod_floor(&q);
+        ry = r_point.y_coor().mod_floor(&q);
     } else {
         return Err(());
     }

--- a/mpc-wallet/mpc-wallet-lib/src/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/server.rs
@@ -2,7 +2,7 @@
  * Server functions for MPC-based API keys
  */
 
-use crate::common::{correct_key_proof_rho, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
+use crate::common::{correct_key_proof_rho, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE, verify};
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
@@ -98,6 +98,8 @@ pub fn complete_sig(
     r: &BigInt,
     k: &BigInt,
     curve: Curve,
+    pubkey_str: &str,
+    msg_hash: &BigInt,
 ) -> Result<(BigInt, BigInt, u8), ()> {
     let q: BigInt;
     let rx: BigInt;
@@ -122,7 +124,12 @@ pub fn complete_sig(
         return Err(());
     }
     let (s, recid) = complete_sig_curveindependent(&paillier_sk, &presig, &k, &rx, &ry, &q);
-    Ok((rx, s, recid))
+    // verify that the resulting signature is indeed valid
+    if verify(&rx, &s, pubkey_str, msg_hash, curve) {
+        Ok((rx, s, recid))
+    } else {
+        Err(())
+    }
 }
 
 fn complete_sig_curveindependent(
@@ -163,7 +170,7 @@ fn correct_key_proof_sigma(paillier_sk: &DecryptionKey, rho: &[BigInt]) -> Vec<B
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
+    use crate::common::{CorrectKeyProof, Curve, PAILLIER_KEY_SIZE, publickey_from_secretkey};
     use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
     use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
     use crate::curves::traits::ECScalar;
@@ -355,7 +362,11 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
         assert_eq!(
             r_,
             BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
@@ -370,6 +381,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_k1_wrong_paillier() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("f3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("4eef881b16b678841b4688be1609cf3eb4b9d31b00e74d9f2c0a7c6e827a43eb099099802893d7568655db7ceb590092a09f2d3154e4c25527091c50e8b956104e03f6ec04bd13158341d1728f7f0e9aa9e9664e0fbfcca06a2fbb97a48ddbf6e86d39b58cd8581b494b084f6b2d1d70f66994da6b7c73a034f0580b77658aed33517b7cf6b6cfb6e23a67001ab4caa49ed8445890a74d60ecac4140cc0ae9817a7d974deb1111784c0ad400ae30c74e421d0f5f31b42364c44b577be00ef13deb2a2d9c90b913abfad7056fb2e9d86f1ad521441f7a58b264c56b5da86e1d07a84d50ef28c711d023ca5f7c8759d4aa9d6fc83db5be69c05d8a6804a344c169e3dc7ab542283f1f03151bade022ce18685f0142523fb27154e29104efb10757e5be11c669c4a16d1de7d294d019c0a742cf64f0b91953ff36da960ac55aa023ff10fd9410bfb0fe5f68210d93a7c67d4e743aaae7aef6659b90a0b23e7ad267514ec359624581b8d6a1fd839db0ab05c1ab82192214c3e3d26b337d4937fd9a4d1c78d843c511e6de4f4f44fe7784a7edc33fdabd222be0c6600d38c55f48967847f17f6f049fe4b0ac485010226c16eece202a34b357d5acee6109d5bccfa3a61a79c80ddebb8c2cef192afa0440452739bbe55fc94b6a0af2d98328196b6041e584215a399ce615cfd697c6cca8ea30bac926de61b636d4029a226955854d").unwrap();
@@ -380,21 +392,15 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("4b4b24ef84023a5a37bc9b3524060a6339bd71ca7520b4c0972a80e79995843e")
-                .unwrap()
-        );
-        assert_ne!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_k1_wrong_presig() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("5eef881b16b678841b4688be1609cf3eb4b9d31b00e74d9f2c0a7c6e827a43eb099099802893d7568655db7ceb590092a09f2d3154e4c25527091c50e8b956104e03f6ec04bd13158341d1728f7f0e9aa9e9664e0fbfcca06a2fbb97a48ddbf6e86d39b58cd8581b494b084f6b2d1d70f66994da6b7c73a034f0580b77658aed33517b7cf6b6cfb6e23a67001ab4caa49ed8445890a74d60ecac4140cc0ae9817a7d974deb1111784c0ad400ae30c74e421d0f5f31b42364c44b577be00ef13deb2a2d9c90b913abfad7056fb2e9d86f1ad521441f7a58b264c56b5da86e1d07a84d50ef28c711d023ca5f7c8759d4aa9d6fc83db5be69c05d8a6804a344c169e3dc7ab542283f1f03151bade022ce18685f0142523fb27154e29104efb10757e5be11c669c4a16d1de7d294d019c0a742cf64f0b91953ff36da960ac55aa023ff10fd9410bfb0fe5f68210d93a7c67d4e743aaae7aef6659b90a0b23e7ad267514ec359624581b8d6a1fd839db0ab05c1ab82192214c3e3d26b337d4937fd9a4d1c78d843c511e6de4f4f44fe7784a7edc33fdabd222be0c6600d38c55f48967847f17f6f049fe4b0ac485010226c16eece202a34b357d5acee6109d5bccfa3a61a79c80ddebb8c2cef192afa0440452739bbe55fc94b6a0af2d98328196b6041e584215a399ce615cfd697c6cca8ea30bac926de61b636d4029a226955854d").unwrap();
@@ -405,21 +411,15 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("4b4b24ef84023a5a37bc9b3524060a6339bd71ca7520b4c0972a80e79995843e")
-                .unwrap()
-        );
-        assert_ne!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_k1_wrong_r() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("4eef881b16b678841b4688be1609cf3eb4b9d31b00e74d9f2c0a7c6e827a43eb099099802893d7568655db7ceb590092a09f2d3154e4c25527091c50e8b956104e03f6ec04bd13158341d1728f7f0e9aa9e9664e0fbfcca06a2fbb97a48ddbf6e86d39b58cd8581b494b084f6b2d1d70f66994da6b7c73a034f0580b77658aed33517b7cf6b6cfb6e23a67001ab4caa49ed8445890a74d60ecac4140cc0ae9817a7d974deb1111784c0ad400ae30c74e421d0f5f31b42364c44b577be00ef13deb2a2d9c90b913abfad7056fb2e9d86f1ad521441f7a58b264c56b5da86e1d07a84d50ef28c711d023ca5f7c8759d4aa9d6fc83db5be69c05d8a6804a344c169e3dc7ab542283f1f03151bade022ce18685f0142523fb27154e29104efb10757e5be11c669c4a16d1de7d294d019c0a742cf64f0b91953ff36da960ac55aa023ff10fd9410bfb0fe5f68210d93a7c67d4e743aaae7aef6659b90a0b23e7ad267514ec359624581b8d6a1fd839db0ab05c1ab82192214c3e3d26b337d4937fd9a4d1c78d843c511e6de4f4f44fe7784a7edc33fdabd222be0c6600d38c55f48967847f17f6f049fe4b0ac485010226c16eece202a34b357d5acee6109d5bccfa3a61a79c80ddebb8c2cef192afa0440452739bbe55fc94b6a0af2d98328196b6041e584215a399ce615cfd697c6cca8ea30bac926de61b636d4029a226955854d").unwrap();
@@ -430,21 +430,15 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_ne!(
-            r_,
-            BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
-                .unwrap()
-        );
-        assert_eq!(
-            s,
-            BigInt::from_hex("4b4b24ef84023a5a37bc9b3524060a6339bd71ca7520b4c0972a80e79995843e")
-                .unwrap()
-        );
-        assert_ne!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_k1_wrong_k() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("4eef881b16b678841b4688be1609cf3eb4b9d31b00e74d9f2c0a7c6e827a43eb099099802893d7568655db7ceb590092a09f2d3154e4c25527091c50e8b956104e03f6ec04bd13158341d1728f7f0e9aa9e9664e0fbfcca06a2fbb97a48ddbf6e86d39b58cd8581b494b084f6b2d1d70f66994da6b7c73a034f0580b77658aed33517b7cf6b6cfb6e23a67001ab4caa49ed8445890a74d60ecac4140cc0ae9817a7d974deb1111784c0ad400ae30c74e421d0f5f31b42364c44b577be00ef13deb2a2d9c90b913abfad7056fb2e9d86f1ad521441f7a58b264c56b5da86e1d07a84d50ef28c711d023ca5f7c8759d4aa9d6fc83db5be69c05d8a6804a344c169e3dc7ab542283f1f03151bade022ce18685f0142523fb27154e29104efb10757e5be11c669c4a16d1de7d294d019c0a742cf64f0b91953ff36da960ac55aa023ff10fd9410bfb0fe5f68210d93a7c67d4e743aaae7aef6659b90a0b23e7ad267514ec359624581b8d6a1fd839db0ab05c1ab82192214c3e3d26b337d4937fd9a4d1c78d843c511e6de4f4f44fe7784a7edc33fdabd222be0c6600d38c55f48967847f17f6f049fe4b0ac485010226c16eece202a34b357d5acee6109d5bccfa3a61a79c80ddebb8c2cef192afa0440452739bbe55fc94b6a0af2d98328196b6041e584215a399ce615cfd697c6cca8ea30bac926de61b636d4029a226955854d").unwrap();
@@ -455,18 +449,11 @@ mod tests {
             BigInt::from_hex("a8779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("7c1adefb68c11af735850d77e24bd0c4dbc256cf100d441d4542d853a81508f3")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("4b4b24ef84023a5a37bc9b3524060a6339bd71ca7520b4c0972a80e79995843e")
-                .unwrap()
-        );
-        assert_ne!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
@@ -481,7 +468,11 @@ mod tests {
             BigInt::from_hex("88779a4565cc853f6a46475963515a6e50330d4e83c4235dbb160e1164d9a730")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
@@ -495,7 +486,11 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
         assert_eq!(
             r_,
             BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
@@ -510,6 +505,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_r1_wrong_paillier() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("4a4f82ec76b17ddfc10b15878713cc31fe914674a36b834da70215670d19997a56db6fa8b38fbdb2672a73aafcb4ba7162f35b1ccc0474622f2d2a50406fcd8cfbbca0ad6adaf3bd6c8d574393a8cca548e88f93383d426bb634a390f21014562ca45c2b739b270e65760ef43fc28fa207bfe6e7e159f8f943e66606037814586d512057c0036e98e6b9e2432723c9b86eb6ecc43def1fd8d608ba8334872be86659690bb10e7da72dcc18df5f316b2e6fc0ff37b351cca3510f48b50053c7de638ebbded1a2bc34ff130ad8df98e7353fb6c9be6893bd6d6fa1b07eb79a0bf815fe6e611ec7c99564b7acca2d7266d7de64b3e7fb4911638c0cda8b5c7896f261971e7a6bb04bca5ff6bb80153aed189d62d899d88727778b12e6d9b6d49b0af2dd5bbcc57a8950cd02a5f993bebcf85eeb3ca36179166b52a188870777dcb6d67d707c07f013c035e33c49e76b91389dabc681d04928bfc27be1acea29c61087caf6f8675c1ef572275d5e724e8ed7dea616d2058ba07a7f261622a7479c2bb63bea79956f7b84202e740a1ff0ddaff3500dfa6ab2dfafd2aa0a3a20629f71ebdeb1328d71ecb4301a95f98ee3b82c87eb286138f30f947ccaa9a1bf042ed829b89550455e2fae3fbc8d7803dc53e6565dc3999d2c739c568e80175e15e4d7e5679cce42fd86f44c7b5c87cccceb7a4f8cbda1ce87f3e3f38beb516f2cf737").unwrap();
@@ -520,21 +516,15 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("271f3513c9ac42e82ba602b76a40a1510902a6671221f77ba881e8d847c82b22")
-                .unwrap()
-        );
-        assert_eq!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_r1_wrong_presig() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("3a5f82ec76b17ddfc10b15878713cc31fe914674a36b834da70215670d19997a56db6fa8b38fbdb2672a73aafcb4ba7162f35b1ccc0474622f2d2a50406fcd8cfbbca0ad6adaf3bd6c8d574393a8cca548e88f93383d426bb634a390f21014562ca45c2b739b270e65760ef43fc28fa207bfe6e7e159f8f943e66606037814586d512057c0036e98e6b9e2432723c9b86eb6ecc43def1fd8d608ba8334872be86659690bb10e7da72dcc18df5f316b2e6fc0ff37b351cca3510f48b50053c7de638ebbded1a2bc34ff130ad8df98e7353fb6c9be6893bd6d6fa1b07eb79a0bf815fe6e611ec7c99564b7acca2d7266d7de64b3e7fb4911638c0cda8b5c7896f261971e7a6bb04bca5ff6bb80153aed189d62d899d88727778b12e6d9b6d49b0af2dd5bbcc57a8950cd02a5f993bebcf85eeb3ca36179166b52a188870777dcb6d67d707c07f013c035e33c49e76b91389dabc681d04928bfc27be1acea29c61087caf6f8675c1ef572275d5e724e8ed7dea616d2058ba07a7f261622a7479c2bb63bea79956f7b84202e740a1ff0ddaff3500dfa6ab2dfafd2aa0a3a20629f71ebdeb1328d71ecb4301a95f98ee3b82c87eb286138f30f947ccaa9a1bf042ed829b89550455e2fae3fbc8d7803dc53e6565dc3999d2c739c568e80175e15e4d7e5679cce42fd86f44c7b5c87cccceb7a4f8cbda1ce87f3e3f38beb516f2cf737").unwrap();
@@ -545,21 +535,15 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("271f3513c9ac42e82ba602b76a40a1510902a6671221f77ba881e8d847c82b22")
-                .unwrap()
-        );
-        assert_eq!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_r1_wrong_r() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("3a4f82ec76b17ddfc10b15878713cc31fe914674a36b834da70215670d19997a56db6fa8b38fbdb2672a73aafcb4ba7162f35b1ccc0474622f2d2a50406fcd8cfbbca0ad6adaf3bd6c8d574393a8cca548e88f93383d426bb634a390f21014562ca45c2b739b270e65760ef43fc28fa207bfe6e7e159f8f943e66606037814586d512057c0036e98e6b9e2432723c9b86eb6ecc43def1fd8d608ba8334872be86659690bb10e7da72dcc18df5f316b2e6fc0ff37b351cca3510f48b50053c7de638ebbded1a2bc34ff130ad8df98e7353fb6c9be6893bd6d6fa1b07eb79a0bf815fe6e611ec7c99564b7acca2d7266d7de64b3e7fb4911638c0cda8b5c7896f261971e7a6bb04bca5ff6bb80153aed189d62d899d88727778b12e6d9b6d49b0af2dd5bbcc57a8950cd02a5f993bebcf85eeb3ca36179166b52a188870777dcb6d67d707c07f013c035e33c49e76b91389dabc681d04928bfc27be1acea29c61087caf6f8675c1ef572275d5e724e8ed7dea616d2058ba07a7f261622a7479c2bb63bea79956f7b84202e740a1ff0ddaff3500dfa6ab2dfafd2aa0a3a20629f71ebdeb1328d71ecb4301a95f98ee3b82c87eb286138f30f947ccaa9a1bf042ed829b89550455e2fae3fbc8d7803dc53e6565dc3999d2c739c568e80175e15e4d7e5679cce42fd86f44c7b5c87cccceb7a4f8cbda1ce87f3e3f38beb516f2cf737").unwrap();
@@ -570,21 +554,15 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_ne!(
-            r_,
-            BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
-                .unwrap()
-        );
-        assert_eq!(
-            s,
-            BigInt::from_hex("271f3513c9ac42e82ba602b76a40a1510902a6671221f77ba881e8d847c82b22")
-                .unwrap()
-        );
-        assert_eq!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
+    #[should_panic]
     fn test_complete_sig_r1_wrong_k() {
         let paillier_sk = DecryptionKey::from(MinimalDecryptionKey{p: BigInt::from_hex("d3542d07cda6034cf8568b68d69f07b716c98dcc466d7fb89d2a40db4addfe1402ac6007b609734c80fa4dd24f005cc2d404651f724561391fd2c714c054c5ecb98c0d367d5d99cddbd788489151daa247feef546ba173db02576793f2386c89a78e1cf0b1b5e3882efb709663c8fb50f3b973e87447bc0a473b792eeb9720ef").unwrap(), q: BigInt::from_hex("bf9f1abdcfd5f3e30a609ad469637eeadf068f67735c319cd0bfe3cb7ed915d93c33c77078762c3deab68fd66a46903a3241f84ccf827ac27faa339d12f4cf818732220b2a899660765a8554d8bc6490bc7490b7874fe1651dccd25b74bcdb5481e1d09bfe3ec6143c2f9bb2cf3658d514fc8c1e48a8e095b8a0f9fe94891f67").unwrap()});
         let presig = BigInt::from_hex("3a4f82ec76b17ddfc10b15878713cc31fe914674a36b834da70215670d19997a56db6fa8b38fbdb2672a73aafcb4ba7162f35b1ccc0474622f2d2a50406fcd8cfbbca0ad6adaf3bd6c8d574393a8cca548e88f93383d426bb634a390f21014562ca45c2b739b270e65760ef43fc28fa207bfe6e7e159f8f943e66606037814586d512057c0036e98e6b9e2432723c9b86eb6ecc43def1fd8d608ba8334872be86659690bb10e7da72dcc18df5f316b2e6fc0ff37b351cca3510f48b50053c7de638ebbded1a2bc34ff130ad8df98e7353fb6c9be6893bd6d6fa1b07eb79a0bf815fe6e611ec7c99564b7acca2d7266d7de64b3e7fb4911638c0cda8b5c7896f261971e7a6bb04bca5ff6bb80153aed189d62d899d88727778b12e6d9b6d49b0af2dd5bbcc57a8950cd02a5f993bebcf85eeb3ca36179166b52a188870777dcb6d67d707c07f013c035e33c49e76b91389dabc681d04928bfc27be1acea29c61087caf6f8675c1ef572275d5e724e8ed7dea616d2058ba07a7f261622a7479c2bb63bea79956f7b84202e740a1ff0ddaff3500dfa6ab2dfafd2aa0a3a20629f71ebdeb1328d71ecb4301a95f98ee3b82c87eb286138f30f947ccaa9a1bf042ed829b89550455e2fae3fbc8d7803dc53e6565dc3999d2c739c568e80175e15e4d7e5679cce42fd86f44c7b5c87cccceb7a4f8cbda1ce87f3e3f38beb516f2cf737").unwrap();
@@ -595,18 +573,11 @@ mod tests {
             BigInt::from_hex("f1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256r1;
-        let (r_, s, recid) = complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
-        assert_eq!(
-            r_,
-            BigInt::from_hex("0a3ec2711ae5dc9e71711dc4d6bf2beb755be5639a9ce1854e258c4c44921fff")
-                .unwrap()
-        );
-        assert_ne!(
-            s,
-            BigInt::from_hex("271f3513c9ac42e82ba602b76a40a1510902a6671221f77ba881e8d847c82b22")
-                .unwrap()
-        );
-        assert_ne!(recid, 28);
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 
     #[test]
@@ -621,6 +592,10 @@ mod tests {
             BigInt::from_hex("e1d1318d8b96ed598ce80f8fb9197327bca23f7db51021a6c5cfb8b01851b2ff")
                 .unwrap();
         let curve = Curve::Secp256k1;
-        complete_sig(&paillier_sk, &presig, &r, &k, curve).unwrap();
+        let pk = publickey_from_secretkey(&BigInt::from_hex("4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1").unwrap(), curve).unwrap();
+        let msg_hash =
+            BigInt::from_hex("000000000000000fffffffffffffffffff00000000000000ffffffffff000000")
+                .unwrap();
+        complete_sig(&paillier_sk, &presig, &r, &k, curve, &pk, &msg_hash).unwrap();
     }
 }

--- a/mpc-wallet/mpc-wallet-lib/src/server.rs
+++ b/mpc-wallet/mpc-wallet-lib/src/server.rs
@@ -3,7 +3,10 @@
  */
 
 use crate::common::{correct_key_proof_rho, verify, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
+#[cfg(feature = "secp256k1")]
 use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+#[cfg(feature = "k256")]
+use crate::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
 use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use crate::curves::traits::{ECPoint, ECScalar};
 #[cfg(feature = "num_bigint")]
@@ -180,7 +183,10 @@ fn correct_key_proof_sigma(paillier_sk: &DecryptionKey, rho: &[BigInt]) -> Vec<B
 #[cfg(test)]
 mod tests {
     use crate::common::{publickey_from_secretkey, CorrectKeyProof, Curve, PAILLIER_KEY_SIZE};
+    #[cfg(feature = "secp256k1")]
     use crate::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+    #[cfg(feature = "k256")]
+    use crate::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
     use crate::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
     use crate::curves::traits::ECScalar;
     use crate::server::{

--- a/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
+++ b/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
@@ -1,5 +1,3 @@
-use rust_bigint::traits::Converter;
-use rust_bigint::BigInt;
 use mpc_wallet_lib::client::{
     compute_presig, fill_rpool_secp256k1, fill_rpool_secp256r1, APIchildkeyCreator,
 };
@@ -11,6 +9,8 @@ use mpc_wallet_lib::server::{
     complete_sig, compute_rpool_secp256k1, compute_rpool_secp256r1, generate_paillier_keypair,
     generate_paillier_proof,
 };
+use rust_bigint::traits::Converter;
+use rust_bigint::BigInt;
 
 #[test]
 fn test_integration_k1() {
@@ -39,7 +39,16 @@ fn test_integration_k1() {
         .unwrap()
         .to_bigint();
     let pk = publickey_from_secretkey(&secret_key, Curve::Secp256k1).unwrap();
-    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256k1, &pk, &msg_hash).unwrap();
+    let (rx, s, _) = complete_sig(
+        &paillier_sk,
+        &presig,
+        &r,
+        &k,
+        Curve::Secp256k1,
+        &pk,
+        &msg_hash,
+    )
+    .unwrap();
     assert!(verify(
         &rx,
         &s,
@@ -76,7 +85,16 @@ fn test_integration_r1() {
         .unwrap()
         .to_bigint();
     let pk = publickey_from_secretkey(&secret_key, Curve::Secp256r1).unwrap();
-    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256r1, &pk, &msg_hash).unwrap();
+    let (rx, s, _) = complete_sig(
+        &paillier_sk,
+        &presig,
+        &r,
+        &k,
+        Curve::Secp256r1,
+        &pk,
+        &msg_hash,
+    )
+    .unwrap();
     assert!(verify(
         &rx,
         &s,

--- a/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
+++ b/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
@@ -38,7 +38,8 @@ fn test_integration_k1() {
         .get(&format!("{:0>66}", r.to_hex()))
         .unwrap()
         .to_big_int();
-    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256k1).unwrap();
+    let pk = publickey_from_secretkey(&secret_key, Curve::Secp256k1).unwrap();
+    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256k1, &pk, &msg_hash).unwrap();
     assert!(verify(
         &rx,
         &s,
@@ -74,7 +75,8 @@ fn test_integration_r1() {
         .get(&format!("{:0>66}", r.to_hex()))
         .unwrap()
         .to_big_int();
-    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256r1).unwrap();
+    let pk = publickey_from_secretkey(&secret_key, Curve::Secp256r1).unwrap();
+    let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256r1, &pk, &msg_hash).unwrap();
     assert!(verify(
         &rx,
         &s,

--- a/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
+++ b/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
@@ -37,7 +37,7 @@ fn test_integration_k1() {
     let k = rpool
         .get(&format!("{:0>66}", r.to_hex()))
         .unwrap()
-        .to_big_int();
+        .to_bigint();
     let pk = publickey_from_secretkey(&secret_key, Curve::Secp256k1).unwrap();
     let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256k1, &pk, &msg_hash).unwrap();
     assert!(verify(
@@ -74,7 +74,7 @@ fn test_integration_r1() {
     let k = rpool
         .get(&format!("{:0>66}", r.to_hex()))
         .unwrap()
-        .to_big_int();
+        .to_bigint();
     let pk = publickey_from_secretkey(&secret_key, Curve::Secp256r1).unwrap();
     let (rx, s, _) = complete_sig(&paillier_sk, &presig, &r, &k, Curve::Secp256r1, &pk, &msg_hash).unwrap();
     assert!(verify(

--- a/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
+++ b/mpc-wallet/mpc-wallet-lib/tests/integration_tests.rs
@@ -45,8 +45,7 @@ fn test_integration_k1() {
         &publickey_from_secretkey(&secret_key, Curve::Secp256k1).unwrap(),
         &msg_hash,
         Curve::Secp256k1,
-    )
-    .unwrap());
+    ));
 }
 
 #[test]
@@ -82,6 +81,5 @@ fn test_integration_r1() {
         &publickey_from_secretkey(&secret_key, Curve::Secp256r1).unwrap(),
         &msg_hash,
         Curve::Secp256r1,
-    )
-    .unwrap());
+    ));
 }

--- a/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2018"
 name = "mpc_wallet_nodejs"
 crate-type = ["cdylib"]
 
+[features]
+default = ["secp256k1"]
+k256 = ["mpc-wallet-lib/k256"]
+secp256k1 = ["mpc-wallet-lib/secp256k1"]
+
 [build-dependencies]
 neon-build = "0.4"
 
@@ -15,7 +20,7 @@ neon-build = "0.4"
 # FIXME: need to pin neon to 0.4.0 until https://github.com/GabrielCastro/neon-serde/issues/61 is fixed
 neon = "=0.4.0"
 neon-serde = "0.4"
-mpc-wallet-lib = { version = "*", path = '../../mpc-wallet-lib', features = ["rust_gmp"] }
+mpc-wallet-lib = { version = "*", path = '../../mpc-wallet-lib', default-features = false, features = ["rust_gmp"] }
 serde_json = "1.0"
 
 [profile.release]

--- a/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
@@ -2,9 +2,11 @@
  * Node.js client interface to MPC-based API keys
  */
 
+#[cfg(feature = "secp256k1")]
 use mpc_wallet_lib::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+#[cfg(feature = "k256")]
+use mpc_wallet_lib::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
 use mpc_wallet_lib::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
-use mpc_wallet_lib::curves::traits::ECScalar;
 use mpc_wallet_lib::paillier_common::EncryptionKey;
 use mpc_wallet_lib::rust_bigint::traits::Converter;
 use mpc_wallet_lib::rust_bigint::BigInt;
@@ -141,35 +143,11 @@ export! {
         ))
         .unwrap()
     }
-
-    /// Generate signature for given message hash under given secret key
-    /// Input: secret_key: full secret key, msg_hash: message hash
-    /// Output: (r, s): ECDSA signature
-    fn sign(secret_key_str: String, msg_hash_str: String) -> String {
-        let secret_key_int = match BigInt::from_hex(&secret_key_str) {
-            Ok(v) => v,
-            Err(_) => {
-                return serde_json::to_string(&(false, &"error deserializing secret_key")).unwrap()
-            }
-        };
-        let secret_key: Secp256k1Scalar = match ECScalar::from(&secret_key_int) {
-            Ok(v) => v,
-            Err(_) => {
-                return serde_json::to_string(&(false, &"invalid secret_key")).unwrap()
-            }
-        };
-        let msg_hash = match BigInt::from_hex(&msg_hash_str) {
-            Ok(v) => v,
-            Err(_) => return serde_json::to_string(&(false, &"error deserializing msg_hash")).unwrap(),
-        };
-        let (r, s) = client::sign(&secret_key, &msg_hash);
-        serde_json::to_string(&(&true, &format!("{:0>64}", r.to_hex()), &format!("{:0>64}", s.to_hex()))).unwrap()
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{compute_presig, dh_init, fill_rpool, get_rpool_size, sign};
+    use crate::{compute_presig, dh_init, fill_rpool, get_rpool_size};
     use mpc_wallet_lib::common::Curve;
 
     #[test]
@@ -362,36 +340,6 @@ mod tests {
 
         let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
         assert_eq!(msg, "error deserializing msg_hash");
-        assert!(!success);
-    }
-
-    #[test]
-    fn test_sign_ok() {
-        let result = sign(
-            "4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1".to_string(),
-            "100000000000000fffffffffffffffffff00000000000000ffffffffff000000".to_string(),
-        );
-        let (success, _, _): (bool, String, String) = serde_json::from_str(&result).unwrap();
-        assert!(success);
-    }
-
-    #[test]
-    fn test_sign_wrong_sk() {
-        let result = sign(
-            "z794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1".to_string(),
-            "100000000000000fffffffffffffffffff00000000000000ffffffffff000000".to_string(),
-        );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert!(!success);
-    }
-
-    #[test]
-    fn test_sign_wrong_hash() {
-        let result = sign(
-            "4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1".to_string(),
-            "\\00000000000000fffffffffffffffffff00000000000000ffffffffff000000".to_string(),
-        );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 }

--- a/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
@@ -152,7 +152,12 @@ export! {
                 return serde_json::to_string(&(false, &"error deserializing secret_key")).unwrap()
             }
         };
-        let secret_key: Secp256k1Scalar = ECScalar::from(&secret_key_int);
+        let secret_key: Secp256k1Scalar = match ECScalar::from(&secret_key_int) {
+            Ok(v) => v,
+            Err(_) => {
+                return serde_json::to_string(&(false, &"invalid secret_key")).unwrap()
+            }
+        };
         let msg_hash = match BigInt::from_hex(&msg_hash_str) {
             Ok(v) => v,
             Err(_) => return serde_json::to_string(&(false, &"error deserializing msg_hash")).unwrap(),

--- a/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-nodejs/native/src/lib.rs
@@ -2,12 +2,12 @@
  * Node.js client interface to MPC-based API keys
  */
 
-use mpc_wallet_lib::rust_bigint::traits::Converter;
-use mpc_wallet_lib::rust_bigint::BigInt;
 use mpc_wallet_lib::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use mpc_wallet_lib::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use mpc_wallet_lib::curves::traits::ECScalar;
 use mpc_wallet_lib::paillier_common::EncryptionKey;
+use mpc_wallet_lib::rust_bigint::traits::Converter;
+use mpc_wallet_lib::rust_bigint::BigInt;
 use mpc_wallet_lib::{client, common};
 use neon::prelude::register_module;
 use neon_serde::export;

--- a/mpc-wallet/mpc-wallet-wasm/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-wasm/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2018"
 name = "mpc_wallet_wasm"
 crate-type = ["cdylib"]
 
+[features]
+default = ["secp256k1"]
+k256 = ["mpc-wallet-lib/k256"]
+secp256k1 = ["mpc-wallet-lib/secp256k1"]
+
 [dependencies]
 console_error_panic_hook = { version = "0.1", optional = true }
 mpc-wallet-lib = { version = "*", path = '../mpc-wallet-lib', default-features = false, features = ["num_bigint", "wasm"] }

--- a/mpc-wallet/mpc-wallet-wasm/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-wasm/src/lib.rs
@@ -2,12 +2,12 @@
  * WASM client interface to MPC-based API keys
  */
 
-use mpc_wallet_lib::rust_bigint::traits::Converter;
-use mpc_wallet_lib::rust_bigint::BigInt;
 use mpc_wallet_lib::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 use mpc_wallet_lib::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
 use mpc_wallet_lib::curves::traits::ECScalar;
 use mpc_wallet_lib::paillier_common::EncryptionKey;
+use mpc_wallet_lib::rust_bigint::traits::Converter;
+use mpc_wallet_lib::rust_bigint::BigInt;
 use mpc_wallet_lib::{client, common};
 use wasm_bindgen::prelude::*;
 
@@ -350,9 +350,7 @@ pub fn sign(secret_key_str: &str, msg_hash_str: &str) -> String {
     };
     let secret_key: Secp256k1Scalar = match ECScalar::from(&secret_key_int) {
         Ok(v) => v,
-        Err(_) => {
-            return serde_json::to_string(&(false, &"invalid secret_key")).unwrap()
-        }
+        Err(_) => return serde_json::to_string(&(false, &"invalid secret_key")).unwrap(),
     };
     let msg_hash = match BigInt::from_hex(&msg_hash_str) {
         Ok(v) => v,

--- a/mpc-wallet/mpc-wallet-wasm/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-wasm/src/lib.rs
@@ -348,7 +348,12 @@ pub fn sign(secret_key_str: &str, msg_hash_str: &str) -> String {
             return serde_json::to_string(&(false, &"error deserializing secret_key")).unwrap()
         }
     };
-    let secret_key: Secp256k1Scalar = ECScalar::from(&secret_key_int);
+    let secret_key: Secp256k1Scalar = match ECScalar::from(&secret_key_int) {
+        Ok(v) => v,
+        Err(_) => {
+            return serde_json::to_string(&(false, &"invalid secret_key")).unwrap()
+        }
+    };
     let msg_hash = match BigInt::from_hex(&msg_hash_str) {
         Ok(v) => v,
         Err(_) => return serde_json::to_string(&(false, &"error deserializing msg_hash")).unwrap(),

--- a/mpc-wallet/mpc-wallet-wasm/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-wasm/src/lib.rs
@@ -2,9 +2,11 @@
  * WASM client interface to MPC-based API keys
  */
 
+#[cfg(feature = "secp256k1")]
 use mpc_wallet_lib::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
+#[cfg(feature = "k256")]
+use mpc_wallet_lib::curves::secp256_k1_rust::{Secp256k1Point, Secp256k1Scalar};
 use mpc_wallet_lib::curves::secp256_r1::{Secp256r1Point, Secp256r1Scalar};
-use mpc_wallet_lib::curves::traits::ECScalar;
 use mpc_wallet_lib::paillier_common::EncryptionKey;
 use mpc_wallet_lib::rust_bigint::traits::Converter;
 use mpc_wallet_lib::rust_bigint::BigInt;
@@ -337,40 +339,12 @@ pub fn publickey_from_secretkey(secret_key_str: &str, curve_str: &str) -> String
     serde_json::to_string(&(&true, &public_key)).unwrap()
 }
 
-/// Generate signature for given message hash under given secret key
-/// Input: secret_key: full secret key, msg_hash: message hash
-/// Output: (r, s): ECDSA signature
-#[wasm_bindgen]
-pub fn sign(secret_key_str: &str, msg_hash_str: &str) -> String {
-    let secret_key_int = match BigInt::from_hex(&secret_key_str) {
-        Ok(v) => v,
-        Err(_) => {
-            return serde_json::to_string(&(false, &"error deserializing secret_key")).unwrap()
-        }
-    };
-    let secret_key: Secp256k1Scalar = match ECScalar::from(&secret_key_int) {
-        Ok(v) => v,
-        Err(_) => return serde_json::to_string(&(false, &"invalid secret_key")).unwrap(),
-    };
-    let msg_hash = match BigInt::from_hex(&msg_hash_str) {
-        Ok(v) => v,
-        Err(_) => return serde_json::to_string(&(false, &"error deserializing msg_hash")).unwrap(),
-    };
-    let (r, s) = client::sign(&secret_key, &msg_hash);
-    serde_json::to_string(&(
-        &true,
-        &format!("{:0>64}", r.to_hex()),
-        &format!("{:0>64}", s.to_hex()),
-    ))
-    .unwrap()
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
         compute_presig, create_api_childkey, dh_init, fill_rpool, get_rpool_size,
         init_api_childkey_creator, init_api_childkey_creator_with_verified_paillier,
-        publickey_from_secretkey, sign, verify, verify_paillier,
+        publickey_from_secretkey, verify, verify_paillier,
     };
     use mpc_wallet_lib::client::{APIchildkey, APIchildkeyCreator};
 
@@ -921,36 +895,6 @@ mod tests {
             "\"Secp256k1\""
         );
         let success: bool = serde_json::from_str(&result).unwrap();
-        assert!(!success);
-    }
-
-    #[test]
-    fn test_sign_ok() {
-        let result = sign(
-            "4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1",
-            "100000000000000fffffffffffffffffff00000000000000ffffffffff000000",
-        );
-        let (success, _, _): (bool, String, String) = serde_json::from_str(&result).unwrap();
-        assert!(success);
-    }
-
-    #[test]
-    fn test_sign_wrong_sk() {
-        let result = sign(
-            "z794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1",
-            "100000000000000fffffffffffffffffff00000000000000ffffffffff000000",
-        );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert!(!success);
-    }
-
-    #[test]
-    fn test_sign_wrong_hash() {
-        let result = sign(
-            "4794853ce9e44b4c7a69c6a3b87db077f8f910f244bb6b966ba5fed83c9756f1",
-            "\\00000000000000fffffffffffffffffff00000000000000ffffffffff000000",
-        );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 }

--- a/mpc-wallet/mpc-wallet-wasm/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-wasm/src/lib.rs
@@ -311,18 +311,7 @@ pub fn verify(
         Err(_) => return serde_json::to_string(&(false, &"error deserializing curve")).unwrap(),
     };
 
-    let result = match common::verify(&r, &s, &pubkey, &msg_hash, curve) {
-        Ok(v) => v,
-        Err(_) => {
-            return serde_json::to_string(&(false, &"error: invalid pubkey or invalid curve"))
-                .unwrap()
-        }
-    };
-    if result {
-        serde_json::to_string(&(&true, &"")).unwrap()
-    } else {
-        serde_json::to_string(&(&false, &"error verifying signature")).unwrap()
-    }
+    serde_json::to_string(&common::verify(&r, &s, &pubkey, &msg_hash, curve)).unwrap()
 }
 
 /// Derive public key from given secret key.
@@ -785,7 +774,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(success);
     }
 
@@ -798,8 +787,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -812,8 +800,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -826,8 +813,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error: invalid pubkey or invalid curve");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -840,8 +826,7 @@ mod tests {
             "100000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -854,8 +839,7 @@ mod tests {
             "100000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error: invalid pubkey or invalid curve");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -868,7 +852,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, _): (bool, String) = serde_json::from_str(&result).unwrap();
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(success);
     }
 
@@ -881,8 +865,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -895,8 +878,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -909,8 +891,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error: invalid pubkey or invalid curve");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -923,8 +904,7 @@ mod tests {
             "010000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256r1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error verifying signature");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 
@@ -937,8 +917,7 @@ mod tests {
             "000000000000000fffffffffffffffffff00000000000000ffffffffff000000",
             "\"Secp256k1\""
         );
-        let (success, msg): (bool, String) = serde_json::from_str(&result).unwrap();
-        assert_eq!(msg, "error: invalid pubkey or invalid curve");
+        let success: bool = serde_json::from_str(&result).unwrap();
         assert!(!success);
     }
 


### PR DESCRIPTION
- verify() now returns a boolean. This will probably need changes in the frontend as well as backend tests.

- verify() call after complete_sig() can be removed from the backend as it is integrated now.

- improved curve trait and secp256k1 integration (no changes to external interfaces).

- proper validation of secp256k1 scalars and points (no changes to external interfaces).

- replace amcl (underlying secp256r1/p256 curve library) with p256 (no changes to external interfaces).

- support for k256 from RustCrypto as potential replacement for rust-secp256k1 to fix compile issues on non-Linux systems. Can be enabled with --no-default-features --feature k256. See https://github.com/nash-io/nash-rust/blob/master/.gitlab-ci.yml for examples.