### PR TITLE
Make trades query available

### DIFF
--- a/nash-protocol/src/graphql/mod.rs
+++ b/nash-protocol/src/graphql/mod.rs
@@ -25,7 +25,7 @@ type AffiliateDeveloperCode = String;
 )]
 pub struct GetOrderbook;
 
-/// Rust constructor for GetOrderbook query
+/// Rust constructor for GetTicker query
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/graphql/schema.json",
@@ -149,3 +149,11 @@ pub struct ListAccountTrades;
     response_derives = "Debug"
 )]
 pub struct ListCandles;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.json",
+    query_path = "src/graphql/queries/list_trades.graphql",
+    response_derives = "Debug"
+)]
+pub struct ListTrades;

--- a/nash-protocol/src/graphql/queries/list_trades.graphql
+++ b/nash-protocol/src/graphql/queries/list_trades.graphql
@@ -1,0 +1,45 @@
+query ListTrades(
+    $marketName: MarketName!
+    $limit: Int
+    $before: PaginationCursor
+  ) {
+    listTrades(marketName: $marketName, limit: $limit, before: $before) {
+      trades {
+        id,
+        accountSide,
+        makerOrderId,
+        takerOrderId,
+        makerReceived {
+          amount,
+          currency
+        },
+        takerReceived {
+          amount,
+          currency
+        }
+        amount {
+          amount,
+          currency
+        },
+        executedAt,
+        makerFee {
+          amount,
+          currency
+        },
+        takerFee {
+          amount,
+          currency
+        },
+        market {
+          name
+        },
+        direction,
+        limitPrice {
+          amount
+          currencyA,
+          currencyB
+        }
+      },
+      next
+    }
+  }

--- a/nash-protocol/src/protocol/list_account_trades/request.rs
+++ b/nash-protocol/src/protocol/list_account_trades/request.rs
@@ -6,7 +6,7 @@ use graphql_client::GraphQLQuery;
 
 impl ListAccountTradesRequest {
     pub fn make_query(&self) -> graphql_client::QueryBody<list_account_trades::Variables> {
-        let get_order = list_account_trades::Variables {
+        let list_account_trades = list_account_trades::Variables {
             payload: list_account_trades::ListAccountTradesParams {
                 before: self.before.clone(),
                 limit: self.limit,
@@ -15,6 +15,6 @@ impl ListAccountTradesRequest {
                 range_stop: self.range.as_ref().map(|x| format!("{:?}", x.stop)),
             },
         };
-        graphql::ListAccountTrades::build_query(get_order)
+        graphql::ListAccountTrades::build_query(list_account_trades)
     }
 }

--- a/nash-protocol/src/protocol/list_candles/request.rs
+++ b/nash-protocol/src/protocol/list_candles/request.rs
@@ -7,7 +7,7 @@ use graphql_client::GraphQLQuery;
 
 impl ListCandlesRequest {
     pub fn make_query(&self) -> graphql_client::QueryBody<list_candles::Variables> {
-        let get_order = list_candles::Variables {
+        let list_candles = list_candles::Variables {
             before: self.before.clone(),
             limit: self.limit,
             market_name: self.market.market_name(),
@@ -16,7 +16,7 @@ impl ListCandlesRequest {
             range_start: self.range.as_ref().map(|x| format!("{:?}", x.start)),
             range_stop: self.range.as_ref().map(|x| format!("{:?}", x.stop)),
         };
-        graphql::ListCandles::build_query(get_order)
+        graphql::ListCandles::build_query(list_candles)
     }
 }
 

--- a/nash-protocol/src/protocol/list_trades/mod.rs
+++ b/nash-protocol/src/protocol/list_trades/mod.rs
@@ -1,0 +1,7 @@
+//! Get exchange trades data
+
+mod request;
+mod response;
+mod types;
+
+pub use types::{ListTradesRequest, ListTradesResponse};

--- a/nash-protocol/src/protocol/list_trades/request.rs
+++ b/nash-protocol/src/protocol/list_trades/request.rs
@@ -1,0 +1,14 @@
+use graphql_client::GraphQLQuery;
+use crate::graphql;
+use crate::graphql::list_trades;
+use super::types::ListTradesRequest;
+
+impl ListTradesRequest {
+    pub fn make_query(&self) -> graphql_client::QueryBody<list_trades::Variables> {
+        graphql::ListTrades::build_query(list_trades::Variables {
+            market_name: self.market.market_name(),
+            limit: self.limit,
+            before: self.before.clone(),
+        })
+    }
+}

--- a/nash-protocol/src/protocol/list_trades/response.rs
+++ b/nash-protocol/src/protocol/list_trades/response.rs
@@ -1,0 +1,72 @@
+use std::convert::TryFrom;
+use std::str::FromStr;
+use chrono::{DateTime, Utc};
+use crate::errors::{ProtocolError, Result};
+use crate::graphql::list_trades;
+use crate::types::{AccountTradeSide, BuyOrSell, Market, Trade};
+use super::types::ListTradesResponse;
+
+impl TryFrom<list_trades::ResponseData> for ListTradesResponse {
+    type Error = ProtocolError;
+
+    fn try_from(response: list_trades::ResponseData) -> Result<ListTradesResponse> {
+        let mut trades = Vec::new();
+
+        for trade_data in response.list_trades.trades {
+            let market = Market::from_str(&trade_data.market.name)?;
+            let taker_fee = market.asset_b.with_amount(&trade_data.taker_fee.amount)?;
+            let maker_fee = market.asset_b.with_amount(&trade_data.maker_fee.amount)?;
+            let amount = market.asset_a.with_amount(&trade_data.amount.amount)?;
+            let maker_received = market
+                .get_asset(&trade_data.maker_received.currency)?
+                .with_amount(&trade_data.maker_received.amount)?;
+            let taker_received = market
+                .get_asset(&trade_data.taker_received.currency)?
+                .with_amount(&trade_data.taker_received.amount)?;
+            let limit_price = market.asset_b.with_amount(&trade_data.limit_price.amount)?;
+
+            trades.push(Trade {
+                id: trade_data.id,
+                taker_order_id: trade_data.taker_order_id.clone(),
+                maker_order_id: trade_data.maker_order_id.clone(),
+                amount,
+                executed_at: DateTime::<Utc>::from_str(&trade_data.executed_at)
+                    .map_err(|_| ProtocolError("Could not convert value to DateTime"))?,
+                account_side: trade_data.account_side.into(),
+                taker_fee,
+                maker_fee,
+                maker_recieved: maker_received,
+                taker_recieved: taker_received,
+                market,
+                direction: trade_data.direction.into(),
+                limit_price,
+            })
+        }
+
+        Ok(ListTradesResponse {
+            trades,
+            next_page: response.list_trades.next.clone(),
+        })
+    }
+}
+
+impl From<list_trades::Direction> for BuyOrSell {
+    fn from(response: list_trades::Direction) -> Self {
+        match response {
+            list_trades::Direction::BUY => Self::Buy,
+            list_trades::Direction::SELL => Self::Sell,
+            _ => panic!("Unexpected value in BuyOrSell enum"),
+        }
+    }
+}
+
+impl From<list_trades::AccountTradeSide> for AccountTradeSide {
+    fn from(trade_side: list_trades::AccountTradeSide) -> Self {
+        match trade_side {
+            list_trades::AccountTradeSide::MAKER => AccountTradeSide::Maker,
+            list_trades::AccountTradeSide::TAKER => AccountTradeSide::Taker,
+            list_trades::AccountTradeSide::NONE => AccountTradeSide::None,
+            _ => panic!("Unsupported value in AccountTradeSide"),
+        }
+    }
+}

--- a/nash-protocol/src/protocol/list_trades/types.rs
+++ b/nash-protocol/src/protocol/list_trades/types.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use futures::lock::Mutex;
+use crate::errors::Result;
+use crate::graphql::list_trades;
+use crate::types::{Market, Trade};
+use super::super::{
+    NashProtocol, ResponseOrError, serializable_to_json, State, try_response_from_json,
+};
+
+/// Get trades associated with market, filtering on several optional fields.
+#[derive(Clone, Debug)]
+pub struct ListTradesRequest {
+    pub market: Market,
+    /// max trades to return
+    pub limit: Option<i64>,
+    /// page before if using pagination
+    pub before: Option<String>,
+}
+
+/// List of trades as well as an optional link to the next page of data.
+#[derive(Debug)]
+pub struct ListTradesResponse {
+    pub trades: Vec<Trade>,
+    pub next_page: Option<String>,
+}
+
+#[async_trait]
+impl NashProtocol for ListTradesRequest {
+    type Response = ListTradesResponse;
+
+    async fn graphql(&self, _state: Arc<Mutex<State>>) -> Result<serde_json::Value> {
+        let query = self.make_query();
+        serializable_to_json(&query)
+    }
+
+    fn response_from_json(
+        &self,
+        response: serde_json::Value,
+    ) -> Result<ResponseOrError<Self::Response>> {
+        try_response_from_json::<ListTradesResponse, list_trades::ResponseData>(response)
+    }
+}

--- a/nash-protocol/src/protocol/mod.rs
+++ b/nash-protocol/src/protocol/mod.rs
@@ -14,6 +14,7 @@ pub mod list_account_orders;
 pub mod list_account_trades;
 pub mod list_candles;
 pub mod list_markets;
+pub mod list_trades;
 pub mod orderbook;
 pub mod place_order;
 pub mod sign_all_states;


### PR DESCRIPTION
This is required by https://github.com/nash-io/openlimits/pull/99
Contents:
- make the listTrade query available through the sdk. This is mostly copy-pasted from list_account_trades