### PR TITLE
Basic asset nonces recovery

### DIFF
--- a/nash-protocol/src/protocol/asset_nonces/types.rs
+++ b/nash-protocol/src/protocol/asset_nonces/types.rs
@@ -63,7 +63,9 @@ impl NashProtocol for AssetNoncesRequest {
         for (key, value) in &response.nonces {
             nonces_map.insert(key.clone(), value.clone());
         }
-        state.lock().await.asset_nonces = Some(nonces_map);
+        let mut state = state.lock().await;
+        state.asset_nonces = Some(nonces_map);
+        state.assets_nonces_refresh = false; // set to false as we just grabbed nonces
         Ok(())
     }
 

--- a/nash-protocol/src/protocol/place_order/types.rs
+++ b/nash-protocol/src/protocol/place_order/types.rs
@@ -178,11 +178,14 @@ impl NashProtocol for LimitOrderRequest {
             }
         }
 
-        // Retrieve asset nonces if we don't have them
-        if let None = state.asset_nonces {
-            hooks.push(ProtocolHook::Protocol(NashProtocolRequest::AssetNonces(
-                AssetNoncesRequest::new(),
-            )));
+        // Retrieve asset nonces if we don't have them or an error triggered need to refresh
+        match (state.asset_nonces.as_ref(), state.assets_nonces_refresh) {
+            (None, _) | (_, true) => {
+                hooks.push(ProtocolHook::Protocol(NashProtocolRequest::AssetNonces(
+                    AssetNoncesRequest::new(),
+                )));
+            }
+            _ => {}
         }
 
         // If we are about to out of orders...
@@ -262,15 +265,18 @@ impl NashProtocol for MarketOrderRequest {
             }
         }
 
-        // Retrieve asset nonces if we don't have them
-        if let None = state.asset_nonces {
-            hooks.push(ProtocolHook::Protocol(NashProtocolRequest::AssetNonces(
-                AssetNoncesRequest::new(),
-            )));
+        // Retrieve asset nonces if we don't have them or an error triggered need to refresh
+        match (state.asset_nonces.as_ref(), state.assets_nonces_refresh) {
+            (None, _) | (_, true) => {
+                hooks.push(ProtocolHook::Protocol(NashProtocolRequest::AssetNonces(
+                    AssetNoncesRequest::new(),
+                )));
+            }
+            _ => {}
         }
 
-        // If have run out of orders...
-        if state.remaining_orders == 0 {
+        // If have run out of orders... (temp setting conservatively)
+        if state.remaining_orders == 20 {
             // Need to sign states
             hooks.push(ProtocolHook::SignAllState(SignAllStates::new()));
             // After signing states, need to update nonces again

--- a/nash-protocol/src/protocol/state.rs
+++ b/nash-protocol/src/protocol/state.rs
@@ -30,6 +30,8 @@ pub struct State {
     pub remaining_orders: u64,
     // optional affiliate code, will recieve a share of fees generated
     pub affiliate_code: Option<String>, // FIXME: move r-pool from global indexmap here
+    pub assets_nonces_refresh: bool,
+    pub state_sign_refersh: bool
 }
 
 impl State {
@@ -45,6 +47,8 @@ impl State {
             markets: None,
             assets: None,
             asset_nonces: None,
+            assets_nonces_refresh: false,
+            state_sign_refersh: false
         })
     }
 
@@ -57,6 +61,8 @@ impl State {
             markets: None,
             assets: None,
             asset_nonces: None,
+            assets_nonces_refresh: false,
+            state_sign_refersh: false
         })
     }
 

--- a/nash-protocol/src/protocol/state.rs
+++ b/nash-protocol/src/protocol/state.rs
@@ -31,7 +31,7 @@ pub struct State {
     // optional affiliate code, will recieve a share of fees generated
     pub affiliate_code: Option<String>, // FIXME: move r-pool from global indexmap here
     pub assets_nonces_refresh: bool,
-    pub state_sign_refersh: bool
+    pub state_sign_refresh: bool // TODO, not 100% we need this
 }
 
 impl State {
@@ -48,7 +48,7 @@ impl State {
             assets: None,
             asset_nonces: None,
             assets_nonces_refresh: false,
-            state_sign_refersh: false
+            state_sign_refresh: false
         })
     }
 


### PR DESCRIPTION
Not totally ideal, but it is probably okay to use this general approach and insert error processing logic in the client network runtime, at least in the short term. A better solution might be to extend the `NashProtocol` trait itself, but quite a bit more involved. The idea here is that error states are saved in `State` and then `NashProtocol` requests can act appropriately given that information. This quick PR should probably be changed such that errors should be parsed from the ME and lead to more refined logic in setting error states