### PR TITLE
Mpc update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,37 +27,43 @@ test-mpc-wallet-wasm:
   script:
     - cd mpc-wallet-wasm
     - cargo build --release
-    - cargo build --features rust_gmp --no-default-features --release
-    - cargo build --features num_bigint --no-default-features --release
+    - cargo build --features secp256k1 --no-default-features --release
+    - cargo build --features k256 --no-default-features --release
     - cargo test --release
-    - cargo test --no-default-features --features rust_gmp --release
-    - cargo test --no-default-features --features num_bigint --release
+    - cargo test --no-default-features --features k256 --release
+    - cargo test --no-default-features --features secp256k1 --release
     - wasm-pack build --release --target bundler
     - wasm-opt -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
     - wasm-pack build --release --target nodejs
     - wasm-opt -Os pkg/mpc_wallet_wasm_bg.wasm -o pkg/mpc_wallet_wasm_bg.wasm
 
-test-bigints:
+test-rust-bigint:
   <<: *rust-template
   stage: test
   script:
-    - cd bigints
+    - cd rust-bigint
     - cargo build --release
     - cargo test --release
     - cargo build --no-default-features --features num_bigint --release
     - cargo test --no-default-features --features num_bigint --release
-    - cargo build --no-default-features --features rust-gmp --release
-    - cargo test --no-default-features --features rust-gmp --release
+    - cargo build --no-default-features --features rust_gmp --release
+    - cargo test --no-default-features --features rust_gmp --release
 
-test-mpc-wallet-lib:
+test-nash-mpc:
   <<: *rust-template
   stage: test
   script:
-    - cd mpc-wallet-lib
-    - cargo build --no-default-features --features rust_gmp --release
-    - cargo test --no-default-features --features rust_gmp --release
-    - cargo build --no-default-features --features num_bigint --release
-    - cargo test --no-default-features --features num_bigint --release
+    - cd nash-mpc
+    - cargo build --release
+    - cargo test --release
+    - cargo build --no-default-features --features rust_gmp --features k256 --release
+    - cargo build --no-default-features --features rust_gmp --features secp256k1 --release
+    - cargo test --no-default-features --features rust_gmp --features k256 --release
+    - cargo test --no-default-features --features rust_gmp --features secp256k1 --release
+    - cargo build --no-default-features --features num_bigint --features k256 --release
+    - cargo build --no-default-features --features num_bigint --features secp256k1 --release
+    - cargo test --no-default-features --features num_bigint --features k256 --release
+    - cargo test --no-default-features --features num_bigint --features secp256k1 --release
 
 test-mpc-wallet-elixir:
   <<: *rust-template
@@ -65,8 +71,8 @@ test-mpc-wallet-elixir:
   script:
     - cd mpc-wallet-elixir
     - cargo build --release
-    - cargo build --no-default-features --features rust_gmp --release
-    - cargo build --no-default-features --features num_bigint --release
+    - cargo build --no-default-features --features k256 --release
+    - cargo build --no-default-features --features secp256k1 --release
 
 test-rust-paillier:
   <<: *rust-template

--- a/mpc-wallet/README
+++ b/mpc-wallet/README
@@ -2,16 +2,12 @@
 Nash's MPC-based API keys
 
 
-mpc-wallet-lib: Rust library for MPC-based API keys. Compiles with stable Rust (i.e., 1.39 as of 11/2019)
+mpc-wallet-lib: Rust library for MPC-based API keys. Compiles with stable Rust. Requires rustc >= 1.51
 
 mpc-wallet-wasm: WASM (full) client interface to MPC-based API keys
 
 mpc-wallet-elixir: Elixir server and client NIFs to MPC-based API keys
 
 mpc-wallet-nodejs: Node.js (limited) client interface to MPC-based API keys
-
-bigints: library for supporting multiple bigint libraries
-
-rust-paillier: patched pure Rust Paillier library
 
 demo: client and server demos using the WASM and Elixir interfaces respectively

--- a/mpc-wallet/mpc-wallet-elixir/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-wallet-elixir"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2018"
 
 [lib]

--- a/mpc-wallet/mpc-wallet-elixir/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-elixir/Cargo.toml
@@ -13,8 +13,8 @@ k256 = ["nash-mpc/k256"]
 secp256k1 = ["nash-mpc/secp256k1"]
 
 [dependencies]
-nash-mpc = { version = "*", path = '../nash-mpc', features = ["rust_gmp", "secp256k1"] }
-rustler = "0.21"
+nash-mpc = { version = "*", path = '../nash-mpc', default-features = false, features = ["rust_gmp"] }
+rustler = "0.22"
 serde_json = "1.0"
 
 [profile.release]

--- a/mpc-wallet/mpc-wallet-elixir/src/lib.rs
+++ b/mpc-wallet/mpc-wallet-elixir/src/lib.rs
@@ -2,9 +2,6 @@
  * Elixir NIFs to MPC-based API keys
  */
 
-#[macro_use]
-extern crate rustler;
-
 #[cfg(feature = "secp256k1")]
 use nash_mpc::curves::secp256_k1::{Secp256k1Point, Secp256k1Scalar};
 #[cfg(feature = "k256")]
@@ -16,40 +13,26 @@ use nash_mpc::rust_bigint::BigInt;
 use nash_mpc::{client, common, server};
 use rustler::{Encoder, Env, Error, Term};
 
-rustler_export_nifs! {
+rustler::init!(
     "Elixir.Server.MPCwallet",
-    [
-    ("generate_paillier_keypair_and_proof", 0, generate_paillier_keypair_and_proof),
-    ("dh_rpool", 2, dh_rpool),
-    ("complete_sig", 7, complete_sig),
-    ("verify", 5, verify),
-    ("compute_presig", 3, compute_presig),
-    ("fill_rpool", 4, fill_rpool),
-    ("dh_init", 2, dh_init),
-    ("init_api_childkey_creator", 1, init_api_childkey_creator),
-    ("init_api_childkey_creator_with_verified_paillier", 2, init_api_childkey_creator_with_verified_paillier),
-    ("verify_paillier", 3, verify_paillier),
-    ("create_api_childkey", 2, create_api_childkey),
-    ("publickey_from_secretkey", 2, publickey_from_secretkey),
-    ],
-    None
-}
+    [generate_paillier_keypair_and_proof, dh_rpool, complete_sig, verify, compute_presig, fill_rpool, dh_init, init_api_childkey_creator, init_api_childkey_creator_with_verified_paillier, verify_paillier, create_api_childkey, publickey_from_secretkey]
+);
 
 mod atoms {
-    rustler_atoms! {
-        atom ok;
-        atom error;
-        atom __true__ = "true";
-        atom __false__ = "false";
+    rustler::atoms! {
+        ok,
+        error,
+        __true__ = "true",
+        __false__ = "false",
     }
 }
 
 /// generate paillier keypair
 /// input: none
 /// output: paillier secret key, paillier public key, proof that paillier key was generated correctly
+#[rustler::nif]
 fn generate_paillier_keypair_and_proof<'a>(
     env: Env<'a>,
-    _args: &[Term<'a>],
 ) -> Result<Term<'a>, Error> {
     let (paillier_pk, paillier_sk) = server::generate_paillier_keypair();
     let correct_key_proof = server::generate_paillier_proof(&paillier_sk);
@@ -68,15 +51,8 @@ fn generate_paillier_keypair_and_proof<'a>(
 /// Diffie-Hellman, compute random and nonce values to be added to the pool as well as a set of public values.
 /// input: client_dh_publics, curve (Secp256r1 or Secp256k1)
 /// output: rpool_new, server_dh_publics
-fn dh_rpool<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let client_dh_publics_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing client_dh_publics").encode(env)),
-    };
-    let curve_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
-    };
+#[rustler::nif]
+fn dh_rpool<'a>(env: Env<'a>, client_dh_publics_str: String, curve_str: String) -> Result<Term<'a>, Error> {
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
@@ -149,54 +125,27 @@ fn dh_rpool<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
 /// finalize presignature to normal ECDSA signature
 /// input: paillier_sk, presig, r, k, curve, pubkey, msg_hash
 /// output: r, s, recid
-fn complete_sig<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let paillier_sk_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing paillier_sk").encode(env)),
-    };
+#[rustler::nif]
+fn complete_sig<'a>(env: Env<'a>, paillier_sk_str: String, presig_str: String, r_str: String, k_str: String, curve_str: String, pubkey: String , msg_hash_str: String) -> Result<Term<'a>, Error> {
     let paillier_sk: DecryptionKey = match serde_json::from_str(&paillier_sk_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing paillier_sk").encode(env)),
-    };
-    let presig_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing presig").encode(env)),
     };
     let presig = match BigInt::from_hex(&presig_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing presig").encode(env)),
     };
-    let r_str: String = match args[2].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing r").encode(env)),
-    };
     let r = match BigInt::from_hex(&r_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing r").encode(env)),
-    };
-    let k_str: String = match args[3].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing k").encode(env)),
     };
     let k = match BigInt::from_hex(&k_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing k").encode(env)),
     };
-    let curve_str: String = match args[4].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
-    };
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
-    };
-    let pubkey: String = match args[5].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing pubkey").encode(env)),
-    };
-    let msg_hash_str: String = match args[6].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing msg_hash").encode(env)),
     };
     let msg_hash = match BigInt::from_hex(&msg_hash_str) {
         Ok(v) => v,
@@ -223,38 +172,19 @@ fn complete_sig<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> 
 /// verify signature for a message under given public key
 /// input: r, s, pubkey, msg_hash, curve
 /// output: ok|error
-fn verify<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let r_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing r").encode(env)),
-    };
+#[rustler::nif]
+fn verify<'a>(env: Env<'a>, r_str: String, s_str: String, pubkey: String, msg_hash_str: String, curve_str: String) -> Result<Term<'a>, Error> {
     let r = match BigInt::from_hex(&r_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing r").encode(env)),
-    };
-    let s_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing s").encode(env)),
     };
     let s = match BigInt::from_hex(&s_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing s").encode(env)),
     };
-    let pubkey: String = match args[2].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing pubkey").encode(env)),
-    };
-    let msg_hash_str: String = match args[3].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing msg_hash").encode(env)),
-    };
     let msg_hash = match BigInt::from_hex(&msg_hash_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing msg_hash").encode(env)),
-    };
-    let curve_str: String = match args[4].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
     };
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
@@ -271,15 +201,8 @@ fn verify<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
 /// Diffie-Hellman: create a set of secret values and a set of public values.
 /// input: n (number of key pairs to generate), curve (Secp256r1 or Secp256k1)
 /// output: dh_secrets, dh_publics
-fn dh_init<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let n: usize = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing n").encode(env)),
-    };
-    let curve_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
-    };
+#[rustler::nif]
+fn dh_init<'a>(env: Env<'a>, n: usize, curve_str: String) -> Result<Term<'a>, Error> {
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
@@ -310,26 +233,15 @@ fn dh_init<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
 /// compute presignature
 /// input: api_childkey, message_hash, curve
 /// output: presignature, r
-fn compute_presig<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let api_childkey_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing api_childkey").encode(env)),
-    };
+#[rustler::nif]
+fn compute_presig<'a>(env: Env<'a>, api_childkey_str: String, msg_hash_str: String, curve_str: String) -> Result<Term<'a>, Error> {
     let api_childkey: client::APIchildkey = match serde_json::from_str(&api_childkey_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing api_childkey").encode(env)),
     };
-    let msg_hash_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing msg_hash").encode(env)),
-    };
     let msg_hash = match BigInt::from_hex(&msg_hash_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing msg_hash").encode(env)),
-    };
-    let curve_str: String = match args[2].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
     };
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
@@ -352,26 +264,11 @@ fn compute_presig<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error
 /// fill pool of r-values from dh secret and public values
 /// input: server_dh_secrets, client_dh_publics, curve, paillier_pk
 /// output: ok|error
-fn fill_rpool<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let server_dh_secrets_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing server_dh_secrets").encode(env)),
-    };
-    let client_dh_publics_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing client_dh_publics").encode(env)),
-    };
-    let curve_str: String = match args[2].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
-    };
+#[rustler::nif]
+fn fill_rpool<'a>(env: Env<'a>, server_dh_secrets_str: String, client_dh_publics_str: String, curve_str: String, paillier_pk_str: String) -> Result<Term<'a>, Error> {
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
-    };
-    let paillier_pk_str: String = match args[3].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing paillier_pk").encode(env)),
     };
     let paillier_pk: EncryptionKey = match serde_json::from_str(&paillier_pk_str) {
         Ok(v) => v,
@@ -433,11 +330,8 @@ fn fill_rpool<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
 /// initialize API child key creation by setting the full secret key
 /// input: secret_key
 /// output: api_childkey_creator
-fn init_api_childkey_creator<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let secret_key_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing secret_key").encode(env)),
-    };
+#[rustler::nif]
+fn init_api_childkey_creator<'a>(env: Env<'a>, secret_key_str: String) -> Result<Term<'a>, Error> {
     let secret_key = match BigInt::from_hex(&secret_key_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing secret_key").encode(env)),
@@ -451,21 +345,15 @@ fn init_api_childkey_creator<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term
 /// initialize API child key creation by setting the full secret key and the paillier public key, assuming that the paillier public key has been verified before.
 /// input: secret_key, paillier_pk
 /// output: apichildkeycreator
+#[rustler::nif]
 fn init_api_childkey_creator_with_verified_paillier<'a>(
     env: Env<'a>,
-    args: &[Term<'a>],
+    secret_key_str: String,
+    paillier_pk_str: String
 ) -> Result<Term<'a>, Error> {
-    let secret_key_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing secret_key").encode(env)),
-    };
     let secret_key = match BigInt::from_hex(&secret_key_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing secret_key").encode(env)),
-    };
-    let paillier_pk_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing paillier_pk").encode(env)),
     };
     let paillier_pk: EncryptionKey = match serde_json::from_str(&paillier_pk_str) {
         Ok(v) => v,
@@ -481,11 +369,8 @@ fn init_api_childkey_creator_with_verified_paillier<'a>(
 /// verify that the Paillier public key was generated correctly.
 /// input: api_childkey_creator, paillier_pk, correct_key_proof
 /// output: api_childkey_creator
-fn verify_paillier<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let api_childkey_creator_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing api_childkey_creator").encode(env)),
-    };
+#[rustler::nif]
+fn verify_paillier<'a>(env: Env<'a>, api_childkey_creator_str: String, paillier_pk_str: String, correct_key_proof_str: String) -> Result<Term<'a>, Error> {
     let api_childkey_creator: client::APIchildkeyCreator =
         match serde_json::from_str(&api_childkey_creator_str) {
             Ok(v) => v,
@@ -495,17 +380,9 @@ fn verify_paillier<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Erro
                 )
             }
         };
-    let paillier_pk_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing paillier_pk").encode(env)),
-    };
     let paillier_pk: EncryptionKey = match serde_json::from_str(&paillier_pk_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing paillier_pk").encode(env)),
-    };
-    let correct_key_proof_str: String = match args[2].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing correct_key_proof").encode(env)),
     };
     let correct_key_proof: common::CorrectKeyProof =
         match serde_json::from_str(&correct_key_proof_str) {
@@ -527,11 +404,8 @@ fn verify_paillier<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Erro
 /// create API childkey
 /// input: api_childkey_creator, curve
 /// output: api_childkey
-fn create_api_childkey<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let api_childkey_creator_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing api_childkey_creator").encode(env)),
-    };
+#[rustler::nif]
+fn create_api_childkey<'a>(env: Env<'a>, api_childkey_creator_str: String, curve_str: String) -> Result<Term<'a>, Error> {
     let api_childkey_creator: client::APIchildkeyCreator =
         match serde_json::from_str(&api_childkey_creator_str) {
             Ok(v) => v,
@@ -541,10 +415,6 @@ fn create_api_childkey<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, 
                 )
             }
         };
-    let curve_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
-    };
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing curve").encode(env)),
@@ -561,18 +431,11 @@ fn create_api_childkey<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, 
 /// Derive public key from given secret key.
 /// input: (full) secret key, curve
 /// output: public_key
-fn publickey_from_secretkey<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let secret_key_str: String = match args[0].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing secret_key").encode(env)),
-    };
+#[rustler::nif]
+fn publickey_from_secretkey<'a>(env: Env<'a>, secret_key_str: String, curve_str: String) -> Result<Term<'a>, Error> {
     let secret_key = match BigInt::from_hex(&secret_key_str) {
         Ok(v) => v,
         Err(_) => return Ok((atoms::error(), &"error deserializing secret_key").encode(env)),
-    };
-    let curve_str: String = match args[1].decode() {
-        Ok(v) => v,
-        Err(_) => return Ok((atoms::error(), &"error parsing curve").encode(env)),
     };
     let curve: common::Curve = match serde_json::from_str(&curve_str) {
         Ok(v) => v,

--- a/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-wallet-nodejs"
-version = "1.1.2"
+version = "1.1.3"
 build = "build.rs"
 edition = "2018"
 

--- a/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-nodejs/native/Cargo.toml
@@ -20,7 +20,7 @@ neon-build = "0.4"
 # FIXME: need to pin neon to 0.4.0 until https://github.com/GabrielCastro/neon-serde/issues/61 is fixed
 neon = "=0.4.0"
 neon-serde = "0.4"
-nash-mpc = { version = "*", path = '../../nash-mpc', features = ["rust_gmp"] }
+nash-mpc = { version = "*", path = '../../nash-mpc', default-features = false, features = ["rust_gmp"] }
 serde_json = "1.0"
 
 [profile.release]

--- a/mpc-wallet/mpc-wallet-wasm/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-wasm/Cargo.toml
@@ -14,7 +14,7 @@ secp256k1 = ["nash-mpc/secp256k1"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1", optional = true }
-nash-mpc = { version = "*", path = '../nash-mpc', features = ["num_bigint", "wasm"] }
+nash-mpc = { version = "*", path = '../nash-mpc', default-features = false, features = ["num_bigint", "wasm"] }
 serde_json = "1.0"
 wasm-bindgen = { version = "0.2" }
 

--- a/mpc-wallet/mpc-wallet-wasm/Cargo.toml
+++ b/mpc-wallet/mpc-wallet-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-wallet-wasm"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2018"
 
 [lib]

--- a/mpc-wallet/nash-mpc/Cargo.toml
+++ b/mpc-wallet/nash-mpc/Cargo.toml
@@ -22,11 +22,11 @@ chrono = "0.4"
 generic-array = "0.14"
 getrandom = "0.2"
 crossbeam-queue = "0.3"
-k256 = { version = "0.7", features = ["ecdsa"], optional = true }
+k256 = { version = "0.9", features = ["ecdsa"], optional = true }
 lazy_static = "1.4"
-p256 = { version = "0.7", features = ["ecdsa"] }
+p256 = { version = "0.9", features = ["ecdsa"] }
 rayon = "1.3"
-secp256k1 = { version = "0.19", optional = true }
+secp256k1 = { version = "0.20", optional = true }
 serde = "1.0"
 sha2 = "0.9"
 subtle = "2.3"

--- a/mpc-wallet/nash-mpc/Cargo.toml
+++ b/mpc-wallet/nash-mpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nash-mpc"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2018"
 description = "MPC wallet library providing threshold signatures for Nash exchange"
 authors = ["Robert Annessi <robert@nash.io>", "Ethan Fast <ethan@nash.io>"]

--- a/mpc-wallet/nash-mpc/Cargo.toml
+++ b/mpc-wallet/nash-mpc/Cargo.toml
@@ -33,8 +33,8 @@ subtle = "2.3"
 num-integer = { version = "0.1", optional = true }
 num-traits = { version = "0.2", optional = true }
 zeroize = { version = "1.1", default-features = false }
-rust-bigint = { version = "1.1", default-features = false }
-paillier-common = { version = "0.1", default-features = false }
+rust-bigint = { version = "1.2", default-features = false }
+paillier-common = { version = "0.2", default-features = false }
 hex = "0.4"
 
 [dev-dependencies]

--- a/mpc-wallet/nash-mpc/src/common.rs
+++ b/mpc-wallet/nash-mpc/src/common.rs
@@ -49,7 +49,7 @@ pub struct CorrectKeyProof {
 pub(crate) const CORRECT_KEY_M: usize = 11;
 
 /// Diffie-Hellman: create a set of secret values and a set of public values (using curve secp256r1)
-pub fn dh_init_secp256r1(n: u32) -> Result<(Vec<Secp256r1Scalar>, Vec<Secp256r1Point>), ()> {
+pub fn dh_init_secp256r1(n: usize) -> Result<(Vec<Secp256r1Scalar>, Vec<Secp256r1Point>), ()> {
     // don't allow creating too many values at once.
     if n > 100 {
         return Err(());
@@ -73,7 +73,7 @@ pub fn dh_init_secp256r1(n: u32) -> Result<(Vec<Secp256r1Scalar>, Vec<Secp256r1P
 }
 
 /// Diffie-Hellman: create a set of secret values and a set of public values (using curve secp256k1)
-pub fn dh_init_secp256k1(n: u32) -> Result<(Vec<Secp256k1Scalar>, Vec<Secp256k1Point>), ()> {
+pub fn dh_init_secp256k1(n: usize) -> Result<(Vec<Secp256k1Scalar>, Vec<Secp256k1Point>), ()> {
     // don't allow creating too many values at once.
     if n > 100 {
         return Err(());

--- a/mpc-wallet/nash-mpc/src/curves/secp256_k1_rust.rs
+++ b/mpc-wallet/nash-mpc/src/curves/secp256_k1_rust.rs
@@ -836,10 +836,10 @@ mod tests {
     fn add_sub_point() {
         let g = Secp256k1Point::generator();
         let i: Secp256k1Scalar = ECScalar::from(&BigInt::from(3)).unwrap();
-        assert_eq!(((g + g).unwrap() + g).unwrap().ge, (g * i).unwrap().ge);
+        assert_eq!(((g.clone() + g.clone()).unwrap() + g.clone()).unwrap().ge, (g.clone() * i).unwrap().ge);
         assert_eq!(
-            (g + g).unwrap().ge,
-            (((g + g).unwrap() - g).unwrap() + g).unwrap().ge
+            (g.clone() + g.clone()).unwrap().ge,
+            (((g.clone() + g.clone()).unwrap() - g.clone()).unwrap() + g.clone()).unwrap().ge
         );
     }
 

--- a/mpc-wallet/nash-mpc/src/curves/secp256_k1_rust.rs
+++ b/mpc-wallet/nash-mpc/src/curves/secp256_k1_rust.rs
@@ -5,6 +5,7 @@ use generic_array::typenum::U32;
 use generic_array::GenericArray;
 use getrandom::getrandom;
 use k256::ecdsa::VerifyingKey;
+use k256::elliptic_curve::group::prime::PrimeCurveAffine;
 use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use k256::{AffinePoint, EncodedPoint, ProjectivePoint, Scalar};
 #[cfg(feature = "num_bigint")]

--- a/mpc-wallet/nash-mpc/src/curves/secp256_r1.rs
+++ b/mpc-wallet/nash-mpc/src/curves/secp256_r1.rs
@@ -842,10 +842,10 @@ mod tests {
     fn add_sub_point() {
         let g = Secp256r1Point::generator();
         let i: Secp256r1Scalar = ECScalar::from(&BigInt::from(3)).unwrap();
-        assert_eq!(((g + g).unwrap() + g).unwrap().ge, (g * i).unwrap().ge);
+        assert_eq!(((g.clone() + g.clone()).unwrap() + g.clone()).unwrap().ge, (g.clone() * i).unwrap().ge);
         assert_eq!(
-            (g + g).unwrap().ge,
-            (((g + g).unwrap() - g).unwrap() + g).unwrap().ge
+            (g.clone() + g.clone()).unwrap().ge,
+            (((g.clone() + g.clone()).unwrap() - g.clone()).unwrap() + g.clone()).unwrap().ge
         );
     }
 

--- a/mpc-wallet/nash-mpc/src/curves/secp256_r1.rs
+++ b/mpc-wallet/nash-mpc/src/curves/secp256_r1.rs
@@ -7,6 +7,7 @@ use getrandom::getrandom;
 #[cfg(feature = "num_bigint")]
 use num_traits::identities::Zero;
 use p256::ecdsa::VerifyingKey;
+use p256::elliptic_curve::group::prime::PrimeCurveAffine;
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256::{AffinePoint, EncodedPoint, ProjectivePoint, Scalar};
 use rust_bigint::traits::Converter;

--- a/nash-protocol/Cargo.toml
+++ b/nash-protocol/Cargo.toml
@@ -31,7 +31,7 @@ graphql_client = "0.9"
 hex = "0.4"
 Inflector = "0.11"
 k256 = { version = "0.9", features = ["ecdsa", "sha256"], optional = true }
-nash-mpc = { version = "1.2", path = "../mpc-wallet/nash-mpc", default-features = false }
+nash-mpc = { version = "1.2.4", path = "../mpc-wallet/nash-mpc", default-features = false }
 num-traits = "0.2"
 ripemd160 = "0.9"
 rust-bigint = { version = "1.2", default-features = false }

--- a/nash-protocol/Cargo.toml
+++ b/nash-protocol/Cargo.toml
@@ -30,11 +30,11 @@ byteorder = "1.3"
 graphql_client = "0.9"
 hex = "0.4"
 Inflector = "0.11"
-k256 = { version = "0.7", features = ["ecdsa", "sha256"], optional = true }
-nash-mpc = { version = "1.2.3", path = "../mpc-wallet/nash-mpc", default-features = false }
+k256 = { version = "0.9", features = ["ecdsa", "sha256"], optional = true }
+nash-mpc = { version = "1.2", path = "../mpc-wallet/nash-mpc", default-features = false }
 num-traits = "0.2"
 ripemd160 = "0.9"
-rust-bigint = { version = "1.1", default-features = false }
+rust-bigint = { version = "1.2", default-features = false }
 secp256k1 = { version = "0.19", optional = true }
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
The PR updates a few dependencies in the MPC library. Most importantly the rust-bigint library to version 1.2. (and paillier-common to version 0.2), soon to be updated on crates.io. The new version of rust-bigint fixes a (very slow) memory leak.